### PR TITLE
Updated small typo in forms-plug docs

### DIFF
--- a/docs/plugins/forms-plugin.md
+++ b/docs/plugins/forms-plugin.md
@@ -8,7 +8,7 @@ repo_link: /forms-plugin
 ---
 
 # Forms plugin
-Plugin adds support form forms. Any form that matches the [formSelector](#formSelector) is sent via swup (with transition).
+Plugin adds support for forms. Any form that matches the [formSelector](#formSelector) is sent via swup (with transition).
 
 Swup will take the form data and submit it with appropriate `method` and `action` based on form attributes, where method defaults to `GET` and action defaults to current url.
 In case of `GET` method, swup serializes the data into url. 


### PR DESCRIPTION
Hi,

I was reading form-plugin docs last night. Originally it reads "Plugin adds support form forms." I think it should read "Plugin adds support for forms." ....Maybe?

Apologies if I have not followed the correct contribution flow, this is like my second PR ever.

Thanks

Tim