### PR TITLE
Add Fred Adams Link to Other Links

### DIFF
--- a/assets/js/other-links-config.js
+++ b/assets/js/other-links-config.js
@@ -34,4 +34,10 @@ window.otherLinksConfig = [
         img: 'https://user-images.githubusercontent.com/9338324/50801034-54238180-12e3-11e9-9571-f7dc75f13092.gif',
         link: 'https://github.com/gmrchk/webftp',
     },
+    {
+        name: 'Fred Adams',
+        description: 'Personal website of Fred Adams, young web developer',
+        img: 'https://xtrp.io/api/content/static_files/misc/fred_adams_small_v2_ad.jpg',
+        link: 'https://xtrp.io/'
+    }
 ];


### PR DESCRIPTION
Adds link for Fred Adams's website to the "You might also like..." links on the docs. Follows same object format as all other links in the JavaScript file, and the image is of a valid size.