### PR TITLE
Remove analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,7 @@ aux_links:
 
 # Google Analytics Tracking (optional)
 # e.g, UA-1234567-89
-ga_tracking: UA-65615068-6
+ga_tracking: nil
 
 # Build settings
 markdown: kramdown

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -34,7 +34,7 @@ aux_links:
 
 # Google Analytics Tracking (optional)
 # e.g, UA-1234567-89
-ga_tracking: UA-65615068-6
+ga_tracking: nil
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
Just a suggestion. Do we need analytics? If yes, we should ask for consent before tracking visitors. Personally, I'd prefer removing it altogether.