### PR TITLE
Preserve existing plugin readme headers while copying from remote repos

### DIFF
--- a/lib/tasks/download-plugin-readmes.js
+++ b/lib/tasks/download-plugin-readmes.js
@@ -50,6 +50,8 @@ function downloadReadme(plugin) {
 }
 
 function download(url, dest, cb) {
+  var {frontMatter, title} = getExistingFrontMatterAndTitle(dest);
+  
   var request = http
     .get(url, function (response) {
       if( response.statusCode === 404 ) {
@@ -60,6 +62,7 @@ function download(url, dest, cb) {
       response.pipe(file);
       file.on("finish", function () {
         file.close(cb);
+        injectExistingFrontmatterAndTitle(dest, frontMatter, title);
       });
     })
     .on("error", function (err) {
@@ -74,4 +77,21 @@ function logCompleteMessage() {
   console.warn('Use your own judgement about which changes to a plugin\'s readme are important and need to be included in the docs.');
   console.warn('Consider the naming of headings, e.g. remove the `Swup ` prefix from the page title.');
   console.warn('Make sure to keep or restore any existing markdown frontmatter.', '\n');
+}
+
+function getExistingFrontMatterAndTitle(path) {
+  var fileContents = fs.readFileSync(path, 'utf-8');
+  var frontMatterMatch = fileContents.match(/(^\s*---.*---\s*$)/ms);
+  var titleMatch = fileContents.match(/^\s*---.*---\s*$.+?(#.*?$)/ms);
+  return {
+    frontMatter: frontMatterMatch ? frontMatterMatch[1] : '',
+    title: titleMatch ? titleMatch[1] : ''
+  };
+}
+
+function injectExistingFrontmatterAndTitle(path, frontMatter, title) {
+  var fileContents = fs.readFileSync(path, 'utf-8');
+  if( title ) fileContents = fileContents.replace(/^#.+?$/m, title)
+  if( frontMatter ) fileContents = frontMatter + '\n' + fileContents;
+  fs.writeFileSync(path, fileContents);
 }


### PR DESCRIPTION
Keeps the frontmatter and title of the plugin READMEs while running the copy routine. If it proves reliable we can revamp the warning message. But first, please test it :)