### PR TITLE
Upgrade node version for build workflow

### DIFF
--- a/.github/workflows/run-swup-tests.yml
+++ b/.github/workflows/run-swup-tests.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Update Node.js and npm
         run: |
-            curl -sSL "https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v12.18.1-linux-x64/bin/node
+            curl -sSL "https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v16.13.0-linux-x64/bin/node
             curl https://www.npmjs.com/install.sh | sudo bash
             
       - name: Install puppeteer dependencies


### PR DESCRIPTION
Builds and tests are failing since pinned `node@12` is installed with `npm@latest`, causing incompatibility.

Fixed by pinning `node@16` for now. Should think about pinning `npm@8` or something as well.