### PR TITLE
Optimize inline code styles

### DIFF
--- a/src/_assets/scss/inc/_code-inline.scss
+++ b/src/_assets/scss/inc/_code-inline.scss
@@ -1,4 +1,6 @@
 *:not(pre) > code:not([class]) {
+	font-family: $mono-font-family;
+	font-size: 0.85em;
 	padding: 0.2rem 0.25rem;
 	background-image: linear-gradient(
 		-170deg,


### PR DESCRIPTION
- Use same font family as the fenced code blocks
- Make the font a bit smaller

Before: 

![image](https://user-images.githubusercontent.com/869813/233120146-83f99b23-73e7-474f-97c8-d347164ee701.png)

After: 

![image](https://user-images.githubusercontent.com/869813/233120224-a0e091c2-24f9-42bb-9dc3-36a68e742310.png)
