### PR TITLE
feat: handle external links

### DIFF
--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -15,6 +15,7 @@
   {% if external_link %}
     <!-- This page is merely a redirect, exclude it from search engines -->
     <meta name="robots" content="noindex, follow">
+    <meta http-equiv="refresh" content="0; URL='{{ external_link }}'">
   {% endif %}
 
 

--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -12,6 +12,11 @@
     <title>Swup - complete, flexible, extensible and easy to use page transition library.</title>
   {% endif %}
 
+  {% if external_link %}
+    <!-- This page is merely a redirect, exclude it from search engines -->
+    <meta name="robots" content="noindex, follow">
+  {% endif %}
+
 
   {% if site.ga_tracking != nil %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga_tracking }}"></script>

--- a/src/_layouts/default.njk
+++ b/src/_layouts/default.njk
@@ -24,8 +24,10 @@
             <a href="{{ repo_link }}" class="btn btn-repo fs-5 mb-4">Repo</a>
           {% endif %}
           {% if external_link %}
-          <h1>{{ title }} </h1>
-          <p>You will be redirected to <a href="{{ external_link }}">{{ external_link }}</a></p>
+          <article>
+            <h1>{{ title }}</h1>
+            <p>You will be redirected to <a href="{{ external_link }}">{{ external_link }}</a></p>
+          </article>
           {% else %}
           <article data-pagefind-body>
             {{ content | maybeLoadRemoteReadme({repo_link: repo_link, title: title}) | safe }}

--- a/src/_layouts/default.njk
+++ b/src/_layouts/default.njk
@@ -23,9 +23,14 @@
           {% if repo_link %}
             <a href="{{ repo_link }}" class="btn btn-repo fs-5 mb-4">Repo</a>
           {% endif %}
+          {% if external_link %}
+          <h1>{{ title }} </h1>
+          <p>You will be redirected to <a href="{{ external_link }}">{{ external_link }}</a></p>
+          {% else %}
           <article data-pagefind-body>
             {{ content | maybeLoadRemoteReadme({repo_link: repo_link, title: title}) | safe }}
           </article>
+          {% endif %}
           {% if has_children == true and has_toc != false %}
             {% set children_list = collections.all | prepareMenuItems({parentTitle: title}) %}
             <ul>

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -5,9 +5,11 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for page in collections.all %}
+        {% if page.data.external_link == null %}
         <url>
             <loc>{{ site.url }}{{ page.url | url }}</loc>
             <lastmod>{{ page.date.toISOString() }}</lastmod>
         </url>
+        {% endif %}
     {% endfor %}
 </urlset>


### PR DESCRIPTION
Fixes #102

**Description**

For all pages that have a frontmatter property `external_link`:

- Exclude from `sitemap.xml`
- Exclude from search engines (`noindex, follow`)
- Redirect to the URL of `external_link`
- Display a fallback in case redirection is deactivated in the users browser:

![image](https://user-images.githubusercontent.com/869813/234246127-49701950-5b21-4795-bf6d-00608b1ad25f.png)

Example of one of these pages on the Netlify preview site: 
https://deploy-preview-103--splendorous-kataifi-9ae281.netlify.app/docs/third-party-integrations/gtag-plugin/

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)