### PR TITLE
feat: auto-merge dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,14 @@
+name: auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: patch
+          github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Related: https://github.com/swup/swup/issues/625

Auto-merges Dependabot PRs I think the docs are a nice testing ground for this functionality (many dependencies, low risk).

I'm unsure if the `secrets.GH_TOKEN` is available to the docs as well. Need to find out right? :)