### PR TITLE
feat : use navigation plugin

### DIFF
--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -3,6 +3,7 @@ const markdownItAnchor = require('markdown-it-anchor');
 const { execSync } = require('child_process');
 const Shiki = require('markdown-it-shiki').default;
 const EleventyFetch = require('@11ty/eleventy-fetch');
+const eleventyNavigationPlugin = require("@11ty/eleventy-navigation");
 
 const customMarkdownIt = markdownIt({
 	html: true,
@@ -26,6 +27,7 @@ customMarkdownIt.use(Shiki, {
 module.exports = function (eleventyConfig) {
 	eleventyConfig.addFilter('prepareMenuItems', prepareMenuItems);
 	eleventyConfig.addFilter('maybeLoadRemoteReadme', maybeLoadRemoteReadme);
+	eleventyConfig.addPlugin(eleventyNavigationPlugin);
 
 	// Assets will be taken care of by WebPack
 	eleventyConfig.ignores.add('./src/_assets/**');

--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -4,8 +4,6 @@ const { execSync } = require('child_process');
 const Shiki = require('markdown-it-shiki').default;
 const EleventyFetch = require('@11ty/eleventy-fetch');
 const eleventyNavigationPlugin = require('@11ty/eleventy-navigation');
-const { JSDOM } = require('jsdom');
-const siteData = require('./src/_data/site')();
 
 const customMarkdownIt = markdownIt({
 	html: true,
@@ -30,8 +28,6 @@ module.exports = function (eleventyConfig) {
 	eleventyConfig.addFilter('sortByOrder', sortByOrder);
 	eleventyConfig.addFilter('maybeLoadRemoteReadme', maybeLoadRemoteReadme);
 	eleventyConfig.addPlugin(eleventyNavigationPlugin);
-
-	eleventyConfig.addTransform('external-links', transformExternalLinks);
 
 	// Assets will be taken care of by WebPack
 	eleventyConfig.ignores.add('./src/_assets/**');
@@ -67,8 +63,8 @@ function sortByOrder(pages) {
 	return pages.sort((a, b) => {
 		const orders = {
 			a: a.data.eleventyNavigation?.order || 0,
-			b: b.data.eleventyNavigation?.order || 0
-		};
+			b: b.data.eleventyNavigation?.order || 0,
+		}
 		Math.sign(orders.a - orders.b);
 	});
 }
@@ -103,31 +99,4 @@ async function maybeLoadRemoteReadme(content, { repo_link = '', title = '' } = {
 	);
 
 	return customMarkdownIt.render(result);
-}
-
-/**
- * Transform external links in html output files
- * @returns string
- */
-function transformExternalLinks(content, filePath) {
-	// Return early if filePath is not set
-	if (!filePath) return content;
-	// Return early if filePath isn't a html file
-	if (!filePath.endsWith('.html')) return content;
-	// Return early for empty content
-	if (!content.trim()) return content;
-	// Convert the content to a document
-	const jsdom = new JSDOM(content, 'text/html');
-
-	jsdom.window.document.querySelectorAll(`a[href^="http"]`).forEach((link) => {
-		// Make sure this really is an external link
-		if (link.href.startsWith(siteData.url)) return;
-
-		link.target = '_blank';
-		link.rel = 'noopener';
-		link.classList.add('external-link');
-	});
-
-	// Return the modified document as a string
-	return jsdom.serialize();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",
         "@11ty/eleventy-fetch": "^4.0.0",
+        "@11ty/eleventy-navigation": "^0.3.5",
         "@swup/cli": "^4.0.3",
         "autoprefixer": "^10.4.2",
         "browserslist": "^4.21.4",
@@ -159,6 +160,19 @@
       },
       "engines": {
         "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy-navigation": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-navigation/-/eleventy-navigation-0.3.5.tgz",
+      "integrity": "sha512-4aKW5aIQDFed8xs1G1pWcEiFPcDSwZtA4IH1eERtoJ+Xy+/fsoe0pzbDmw84bHZ9ACny5jblENhfZhcCxklqQw==",
+      "dev": true,
+      "dependencies": {
+        "dependency-graph": "^0.11.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "esbuild-loader": "^2.18.0",
         "esbuild-plugin-browserslist": "^0.6.0",
         "http-server": "^14.1.1",
+        "jsdom": "^21.1.1",
         "markdown-it": "^13.0.1",
         "markdown-it-anchor": "^8.6.7",
         "markdown-it-shiki": "^0.8.0",
@@ -3429,6 +3430,15 @@
       "resolved": "https://registry.npmjs.org/@swup/theme/-/theme-1.0.7.tgz",
       "integrity": "sha512-OINEaf34fYs90l7/YUUKfOf+paY7/FDhOBLwYxrD0w1OjBiItZpw3N+ATA/QklJwmoUu3KkDFOaQG0zT4KxmmA=="
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -3727,6 +3737,12 @@
       "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
       "dev": true
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "dev": true
+    },
     "node_modules/acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -3738,6 +3754,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
     "node_modules/acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
@@ -3745,6 +3771,15 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -5259,6 +5294,18 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
+      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
+      "dev": true,
+      "dependencies": {
+        "rrweb-cssom": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -5269,6 +5316,54 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
+      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/date-fns": {
@@ -5299,6 +5394,18 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+      "dev": true
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -5402,6 +5509,27 @@
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
       "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "dev": true,
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/domhandler": {
       "version": "2.4.2",
@@ -5735,6 +5863,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -5950,6 +6109,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "node_modules/fastest-levenshtein": {
@@ -6730,6 +6895,32 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/http-server": {
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
@@ -7235,6 +7426,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
     "node_modules/is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
@@ -7488,6 +7685,148 @@
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true
     },
+    "node_modules/jsdom": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.1.tgz",
+      "integrity": "sha512-Jjgdmw48RKcdAIQyUD1UdBh2ecH7VqwaXPN3ehoZN6MqgVbMn+lRm1aAT1AsdJRAJpwfa4IpwgzySn61h2qu3w==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.2",
+        "acorn-globals": "^7.0.0",
+        "cssstyle": "^3.0.0",
+        "data-urls": "^4.0.0",
+        "decimal.js": "^10.4.3",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^12.0.1",
+        "ws": "^8.13.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
+      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jsdom/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -7615,6 +7954,19 @@
       "dev": true,
       "engines": {
         "node": "> 0.8"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lighthouse-logger": {
@@ -8571,6 +8923,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.4.tgz",
+      "integrity": "sha512-NHj4rzRo0tQdijE9ZqAx6kYDcoRwYwSYzCA8MY3JzfxlrvEU0jhnhJT9BhqhJs7I/dKcrDm6TyulaRqZPIhN5g==",
+      "dev": true
+    },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -8687,6 +9045,23 @@
       "dev": true,
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/p-finally": {
@@ -8828,6 +9203,30 @@
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
       "dev": true
+    },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -10214,6 +10613,15 @@
         "node": ">= 4"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
@@ -10529,6 +10937,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -11214,6 +11628,12 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "dev": true
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -11359,6 +11779,18 @@
         "sass-embedded": {
           "optional": true
         }
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/schema-utils": {
@@ -12064,6 +12496,12 @@
       "resolved": "https://registry.npmjs.org/@swup/plugin/-/plugin-1.0.1.tgz",
       "integrity": "sha512-QrTGn1DLx+50CNsk6oGzUFnyNyLkDK6iLb032qKImmAXS+0Dd1cwa8cSGvJ+I27J4qR8y6oJNurgHIEc6ZCTrg=="
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "node_modules/synckit": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
@@ -12334,6 +12772,18 @@
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true
     },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -12580,6 +13030,16 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -12629,6 +13089,18 @@
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
       "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
       "dev": true
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/wait-on": {
       "version": "7.0.1",
@@ -12914,6 +13386,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -13005,6 +13486,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -13052,6 +13542,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/xml2json": {
@@ -13120,6 +13619,12 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
       "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
       "deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
+      "dev": true
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
     "node_modules/yallist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "esbuild-loader": "^2.18.0",
         "esbuild-plugin-browserslist": "^0.6.0",
         "http-server": "^14.1.1",
-        "jsdom": "^21.1.1",
         "markdown-it": "^13.0.1",
         "markdown-it-anchor": "^8.6.7",
         "markdown-it-shiki": "^0.8.0",
@@ -3430,15 +3429,6 @@
       "resolved": "https://registry.npmjs.org/@swup/theme/-/theme-1.0.7.tgz",
       "integrity": "sha512-OINEaf34fYs90l7/YUUKfOf+paY7/FDhOBLwYxrD0w1OjBiItZpw3N+ATA/QklJwmoUu3KkDFOaQG0zT4KxmmA=="
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -3737,12 +3727,6 @@
       "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
       "dev": true
     },
-    "node_modules/abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "dev": true
-    },
     "node_modules/acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -3754,16 +3738,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-globals": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
-      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.1.0",
-        "acorn-walk": "^8.0.2"
-      }
-    },
     "node_modules/acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
@@ -3771,15 +3745,6 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^8"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -5294,18 +5259,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/cssstyle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
-      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
-      "dev": true,
-      "dependencies": {
-        "rrweb-cssom": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -5316,54 +5269,6 @@
       },
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/data-urls": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
-      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
-      "dev": true,
-      "dependencies": {
-        "abab": "^2.0.6",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^12.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/data-urls/node_modules/tr46": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/data-urls/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/data-urls/node_modules/whatwg-url": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
-      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "^4.1.1",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/date-fns": {
@@ -5394,18 +5299,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-      "dev": true
-    },
-    "node_modules/deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -5509,27 +5402,6 @@
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
       "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
-    },
-    "node_modules/domexception": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
-      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-      "dev": true,
-      "dependencies": {
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/domexception/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/domhandler": {
       "version": "2.4.2",
@@ -5863,37 +5735,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-      "dev": true,
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -6109,12 +5950,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
-    },
-    "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "node_modules/fastest-levenshtein": {
@@ -6895,32 +6730,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dev": true,
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/http-proxy-agent/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/http-server": {
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
@@ -7426,12 +7235,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-potential-custom-element-name": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
-    },
     "node_modules/is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
@@ -7685,148 +7488,6 @@
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true
     },
-    "node_modules/jsdom": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.1.tgz",
-      "integrity": "sha512-Jjgdmw48RKcdAIQyUD1UdBh2ecH7VqwaXPN3ehoZN6MqgVbMn+lRm1aAT1AsdJRAJpwfa4IpwgzySn61h2qu3w==",
-      "dev": true,
-      "dependencies": {
-        "abab": "^2.0.6",
-        "acorn": "^8.8.2",
-        "acorn-globals": "^7.0.0",
-        "cssstyle": "^3.0.0",
-        "data-urls": "^4.0.0",
-        "decimal.js": "^10.4.3",
-        "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.2",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.6.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^12.0.1",
-        "ws": "^8.13.0",
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jsdom/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/jsdom/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/jsdom/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/jsdom/node_modules/tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
-      "dev": true,
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jsdom/node_modules/tr46": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/jsdom/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/jsdom/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/jsdom/node_modules/whatwg-url": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
-      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "^4.1.1",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -7954,19 +7615,6 @@
       "dev": true,
       "engines": {
         "node": "> 0.8"
-      }
-    },
-    "node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/lighthouse-logger": {
@@ -8923,12 +8571,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/nwsapi": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.4.tgz",
-      "integrity": "sha512-NHj4rzRo0tQdijE9ZqAx6kYDcoRwYwSYzCA8MY3JzfxlrvEU0jhnhJT9BhqhJs7I/dKcrDm6TyulaRqZPIhN5g==",
-      "dev": true
-    },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -9045,23 +8687,6 @@
       "dev": true,
       "bin": {
         "opener": "bin/opener-bin.js"
-      }
-    },
-    "node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/p-finally": {
@@ -9203,30 +8828,6 @@
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
       "dev": true
-    },
-    "node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dev": true,
-      "dependencies": {
-        "entities": "^4.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -10613,15 +10214,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
@@ -10937,12 +10529,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -11628,12 +11214,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
     },
-    "node_modules/rrweb-cssom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
-      "dev": true
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -11779,18 +11359,6 @@
         "sass-embedded": {
           "optional": true
         }
-      }
-    },
-    "node_modules/saxes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
-      "dependencies": {
-        "xmlchars": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=v12.22.7"
       }
     },
     "node_modules/schema-utils": {
@@ -12496,12 +12064,6 @@
       "resolved": "https://registry.npmjs.org/@swup/plugin/-/plugin-1.0.1.tgz",
       "integrity": "sha512-QrTGn1DLx+50CNsk6oGzUFnyNyLkDK6iLb032qKImmAXS+0Dd1cwa8cSGvJ+I27J4qR8y6oJNurgHIEc6ZCTrg=="
     },
-    "node_modules/symbol-tree": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true
-    },
     "node_modules/synckit": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
@@ -12772,18 +12334,6 @@
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true
     },
-    "node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -13030,16 +12580,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -13089,18 +12629,6 @@
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
       "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
       "dev": true
-    },
-    "node_modules/w3c-xmlserializer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
-      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
-      "dev": true,
-      "dependencies": {
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/wait-on": {
       "version": "7.0.1",
@@ -13386,15 +12914,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -13486,15 +13005,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -13542,15 +13052,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/xml2json": {
@@ -13619,12 +13120,6 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
       "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
       "deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "dev": true
-    },
-    "node_modules/xmlchars": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "esbuild-loader": "^2.18.0",
     "esbuild-plugin-browserslist": "^0.6.0",
     "http-server": "^14.1.1",
-    "jsdom": "^21.1.1",
     "markdown-it": "^13.0.1",
     "markdown-it-anchor": "^8.6.7",
     "markdown-it-shiki": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@11ty/eleventy": "^2.0.1",
     "@11ty/eleventy-fetch": "^4.0.0",
+    "@11ty/eleventy-navigation": "^0.3.5",
     "@swup/cli": "^4.0.3",
     "autoprefixer": "^10.4.2",
     "browserslist": "^4.21.4",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "esbuild-loader": "^2.18.0",
     "esbuild-plugin-browserslist": "^0.6.0",
     "http-server": "^14.1.1",
+    "jsdom": "^21.1.1",
     "markdown-it": "^13.0.1",
     "markdown-it-anchor": "^8.6.7",
     "markdown-it-shiki": "^0.8.0",

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -77,9 +77,26 @@ function addHeadlineLinks() {
 		});
 }
 
+function isTouch() {
+	return !window.matchMedia('(hover: hover)').matches;
+}
+
+function prepareExternalLinks() {
+	// Don't do anything on touch devices
+	if (isTouch()) return;
+	// Open external links in a new tab for very specific contexts, only
+	document
+		.querySelectorAll('.navigation-list a[href], .main-content ul a[href]')
+		.forEach((el) => {
+			if (el.origin === window.location.origin) return;
+			el.target = '_blank';
+		});
+}
+
 function initPageView() {
 	checkTheme();
 	addHeadlineLinks();
+	prepareExternalLinks();
 }
 swup.on('pageView', initPageView);
 initPageView();

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -77,10 +77,12 @@ function addHeadlineLinks() {
 		});
 }
 
-checkTheme();
-swup.on('pageView', checkTheme);
-addHeadlineLinks();
-swup.on('pageView', addHeadlineLinks);
+function initPageView() {
+	checkTheme();
+	addHeadlineLinks();
+}
+swup.on('pageView', initPageView);
+initPageView();
 
 function resetSearch() {
 	document.querySelector('.pagefind-ui__search-clear')?.click();

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -61,6 +61,7 @@ function addHeadlineLinks() {
 		.getElementById('main-content')
 		.querySelectorAll('h2, h3, h4, h5, h6')
 		.forEach(function (element) {
+			if (!element.matches('[id]')) return;
 			const anchor = document.createElement('a');
 			const link = window.location.origin + window.location.pathname + '#' + element.id;
 

--- a/src/_assets/scss/inc/_base.scss
+++ b/src/_assets/scss/inc/_base.scss
@@ -80,7 +80,7 @@ a {
 	text-decoration: none;
 }
 
-.main-content a:not(.btn),
+.main-content a,
 .btn-link {
 	text-decoration: none;
 	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%);

--- a/src/_assets/scss/inc/_base.scss
+++ b/src/_assets/scss/inc/_base.scss
@@ -108,6 +108,9 @@ a {
 		background-size: 1px 6px, 1.2em;
 	}
 }
+.headline-anchor {
+	font-weight: normal;
+}
 
 figure {
 	margin: 0;

--- a/src/_assets/scss/inc/_base.scss
+++ b/src/_assets/scss/inc/_base.scss
@@ -14,6 +14,9 @@
 :root {
 	--pagefind-ui-scale: 0.7;
 	--pagefind-ui-font: $body-font-family;
+	--external-link-icon-light: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23222' stroke-width='1' stroke-linecap='round' stroke-linejoin='round' %3E%3Cline x1='7' y1='17' x2='17' y2='7'%3E%3C/line%3E%3Cpolyline points='7 7 17 7 17 17'%3E%3C/polyline%3E%3C/svg%3E");
+	--external-link-icon-dark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='1' stroke-linecap='round' stroke-linejoin='round' %3E%3Cline x1='7' y1='17' x2='17' y2='7'%3E%3C/line%3E%3Cpolyline points='7 7 17 7 17 17'%3E%3C/polyline%3E%3C/svg%3E");
+	--external-link-icon: var(--external-link-icon-light);
 }
 
 html {

--- a/src/_assets/scss/inc/_base.scss
+++ b/src/_assets/scss/inc/_base.scss
@@ -81,6 +81,7 @@ a {
 }
 
 .main-content a:not([class]),
+.main-content a.external-link,
 .btn-link {
 	text-decoration: none;
 	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%);
@@ -108,6 +109,7 @@ a {
 		background-size: 1px 6px, 1.2em;
 	}
 }
+
 .headline-anchor {
 	font-weight: normal;
 }

--- a/src/_assets/scss/inc/_base.scss
+++ b/src/_assets/scss/inc/_base.scss
@@ -80,7 +80,7 @@ a {
 	text-decoration: none;
 }
 
-.main-content a,
+.main-content a:not(.btn),
 .btn-link {
 	text-decoration: none;
 	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%);

--- a/src/_assets/scss/inc/_base.scss
+++ b/src/_assets/scss/inc/_base.scss
@@ -80,7 +80,7 @@ a {
 	text-decoration: none;
 }
 
-a:not([class]),
+.main-content a,
 .btn-link {
 	text-decoration: none;
 	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%);

--- a/src/_assets/scss/inc/_base.scss
+++ b/src/_assets/scss/inc/_base.scss
@@ -80,7 +80,7 @@ a {
 	text-decoration: none;
 }
 
-.main-content a,
+a:not([class]),
 .btn-link {
 	text-decoration: none;
 	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%);

--- a/src/_assets/scss/inc/_base.scss
+++ b/src/_assets/scss/inc/_base.scss
@@ -80,8 +80,7 @@ a {
 	text-decoration: none;
 }
 
-.main-content a:not([class]),
-.main-content a.external-link,
+.main-content a:not(.btn),
 .btn-link {
 	text-decoration: none;
 	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%);
@@ -96,22 +95,6 @@ a {
 	&:hover {
 		background-size: 1px 6px;
 	}
-}
-
-.main-content ul a.external-link {
-	font-weight: 500;
-	padding-right: 1.2em;
-	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%), var(--external-link-icon);
-	background-repeat: repeat-x, no-repeat;
-	background-position: 0 100%, 100% 60%;
-	background-size: 1px 2px, 1.2em;
-	&:hover {
-		background-size: 1px 6px, 1.2em;
-	}
-}
-
-.headline-anchor {
-	font-weight: normal;
 }
 
 figure {

--- a/src/_assets/scss/inc/_base.scss
+++ b/src/_assets/scss/inc/_base.scss
@@ -80,7 +80,7 @@ a {
 	text-decoration: none;
 }
 
-.main-content a:not(.btn),
+.main-content a:not([class]),
 .btn-link {
 	text-decoration: none;
 	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%);
@@ -94,6 +94,18 @@ a {
 
 	&:hover {
 		background-size: 1px 6px;
+	}
+}
+
+.main-content ul a.external-link {
+	font-weight: 500;
+	padding-right: 1.2em;
+	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%), var(--external-link-icon);
+	background-repeat: repeat-x, no-repeat;
+	background-position: 0 100%, 100% 60%;
+	background-size: 1px 2px, 1.2em;
+	&:hover {
+		background-size: 1px 6px, 1.2em;
 	}
 }
 

--- a/src/_assets/scss/inc/_links.scss
+++ b/src/_assets/scss/inc/_links.scss
@@ -82,6 +82,7 @@
 .headline-anchor {
 	margin: 0 0 0 10px;
 	opacity: 0.2;
+	font-weight: normal;
 }
 
 .main-headline .headline-anchor {

--- a/src/_assets/scss/inc/_navigation.scss
+++ b/src/_assets/scss/inc/_navigation.scss
@@ -241,3 +241,14 @@
 	background-color: transparent;
 	background-size: 1.2em;
 }
+
+.main-content ul a.external-link {
+	padding-right: 1.2em;
+	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%), var(--external-link-icon);
+	background-repeat: repeat-x, no-repeat;
+	background-position: 0 100%, 100% 60%;
+	background-size: 1px 2px, 1.2em;
+	&:hover {
+		background-size: 1px 6px, 1.2em;
+	}
+}

--- a/src/_assets/scss/inc/_navigation.scss
+++ b/src/_assets/scss/inc/_navigation.scss
@@ -232,7 +232,8 @@
 	}
 }
 
-.navigation-list a[href^="http"] {
+.navigation-list a[href^="http"],
+.toc a[href^="http"] {
   padding-right: 1.2em;
   content: "\00A0";
   background-image: var(--external-link-icon);
@@ -240,4 +241,14 @@
   background-position: 100% 60%;
   background-color: transparent;
   background-size: 1.2em;
+}
+
+.toc a[href^="http"] {
+	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%), var(--external-link-icon);
+	background-repeat: repeat-x, no-repeat;
+	background-position: 0 100%, 100% 60%;
+	background-size: 1px 2px, 1.2em;
+	&:hover {
+		background-size: 1px 6px, 1.2em;
+	}
 }

--- a/src/_assets/scss/inc/_navigation.scss
+++ b/src/_assets/scss/inc/_navigation.scss
@@ -232,7 +232,8 @@
 	}
 }
 
-.navigation-list a.external-link {
+.navigation-list a[href^='http'],
+.toc a[href^='http'] {
 	padding-right: 1.2em;
 	content: '\00A0';
 	background-image: var(--external-link-icon);
@@ -242,9 +243,7 @@
 	background-size: 1.2em;
 }
 
-.toc a.external-link {
-	font-weight: 500;
-	padding-right: 1.2em;
+.toc a[href^='http'] {
 	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%), var(--external-link-icon);
 	background-repeat: repeat-x, no-repeat;
 	background-position: 0 100%, 100% 60%;

--- a/src/_assets/scss/inc/_navigation.scss
+++ b/src/_assets/scss/inc/_navigation.scss
@@ -60,7 +60,7 @@
 	}
 }
 
-.navigation-list-child-list {
+.navigation-list-item > ul {
 	padding-left: 0;
 	list-style: none;
 
@@ -90,7 +90,7 @@
 		@include fs-5;
 	}
 
-	.navigation-list-child-list {
+	.navigation-list-item > ul {
 		display: block;
 
 		.navigation-list-item {

--- a/src/_assets/scss/inc/_navigation.scss
+++ b/src/_assets/scss/inc/_navigation.scss
@@ -232,8 +232,7 @@
 	}
 }
 
-.navigation-list a[href^='http'],
-.toc a[href^='http'] {
+.navigation-list a.external-link {
 	padding-right: 1.2em;
 	content: '\00A0';
 	background-image: var(--external-link-icon);
@@ -243,7 +242,9 @@
 	background-size: 1.2em;
 }
 
-.toc a[href^='http'] {
+.toc a.external-link {
+	font-weight: 500;
+	padding-right: 1.2em;
 	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%), var(--external-link-icon);
 	background-repeat: repeat-x, no-repeat;
 	background-position: 0 100%, 100% 60%;

--- a/src/_assets/scss/inc/_navigation.scss
+++ b/src/_assets/scss/inc/_navigation.scss
@@ -242,7 +242,8 @@
 	background-size: 1.2em;
 }
 
-.main-content ul a.external-link {
+.toc a.external-link {
+	font-weight: 500;
 	padding-right: 1.2em;
 	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%), var(--external-link-icon);
 	background-repeat: repeat-x, no-repeat;

--- a/src/_assets/scss/inc/_navigation.scss
+++ b/src/_assets/scss/inc/_navigation.scss
@@ -241,14 +241,3 @@
 	background-color: transparent;
 	background-size: 1.2em;
 }
-
-.main-content ul a.external-link {
-	padding-right: 1.2em;
-	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%), var(--external-link-icon);
-	background-repeat: repeat-x, no-repeat;
-	background-position: 0 100%, 100% 60%;
-	background-size: 1px 2px, 1.2em;
-	&:hover {
-		background-size: 1px 6px, 1.2em;
-	}
-}

--- a/src/_assets/scss/inc/_navigation.scss
+++ b/src/_assets/scss/inc/_navigation.scss
@@ -128,7 +128,7 @@
 }
 
 .navigation-list-link {
-	display: block;
+	display: inline-block;
 	padding-top: 0.1rem;
 	padding-bottom: 0.1rem;
 	color: $body-heading-color;
@@ -230,4 +230,14 @@
 			content: '';
 		}
 	}
+}
+
+.navigation-list a[href^="http"] {
+  padding-right: 1.2em;
+  content: "\00A0";
+  background-image: var(--external-link-icon);
+  background-repeat: no-repeat;
+  background-position: 100% 60%;
+  background-color: transparent;
+  background-size: 1.2em;
 }

--- a/src/_assets/scss/inc/_navigation.scss
+++ b/src/_assets/scss/inc/_navigation.scss
@@ -232,18 +232,18 @@
 	}
 }
 
-.navigation-list a[href^="http"],
-.toc a[href^="http"] {
-  padding-right: 1.2em;
-  content: "\00A0";
-  background-image: var(--external-link-icon);
-  background-repeat: no-repeat;
-  background-position: 100% 60%;
-  background-color: transparent;
-  background-size: 1.2em;
+.navigation-list a[href^='http'],
+.toc a[href^='http'] {
+	padding-right: 1.2em;
+	content: '\00A0';
+	background-image: var(--external-link-icon);
+	background-repeat: no-repeat;
+	background-position: 100% 60%;
+	background-color: transparent;
+	background-size: 1.2em;
 }
 
-.toc a[href^="http"] {
+.toc a[href^='http'] {
 	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%), var(--external-link-icon);
 	background-repeat: repeat-x, no-repeat;
 	background-position: 0 100%, 100% 60%;

--- a/src/_assets/scss/inc/_navigation.scss
+++ b/src/_assets/scss/inc/_navigation.scss
@@ -242,8 +242,7 @@
 	background-size: 1.2em;
 }
 
-.toc a.external-link {
-	font-weight: 500;
+.main-content ul a.external-link {
 	padding-right: 1.2em;
 	background-image: linear-gradient(#60ddcd 0%, #60ddcd 100%), var(--external-link-icon);
 	background-repeat: repeat-x, no-repeat;

--- a/src/_assets/scss/inc/support/mixins/_hover.scss
+++ b/src/_assets/scss/inc/support/mixins/_hover.scss
@@ -1,19 +1,19 @@
 @mixin hover {
-  &:not(.is-disabled):not(:disabled) {
-    @media all and (hover: hover) {
-      &:hover {
-        @content;
-      }
-    }
-    &.is-active,
+	&:not(.is-disabled):not(:disabled) {
+		@media all and (hover: hover) {
+			&:hover {
+				@content;
+			}
+		}
+		&.is-active,
 		&:active {
-      @content;
-    }
-  }
+			@content;
+		}
+	}
 }
 
 @mixin hoverSupport {
-  @media all and (hover: hover) {
-    @content;
-  }
+	@media all and (hover: hover) {
+		@content;
+	}
 }

--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -5,7 +5,6 @@
   <link href="/_pagefind/pagefind-ui.css" rel="stylesheet">
   <link href="/assets/just-the-docs.css" rel="stylesheet">
 
-
   {% if title %}
     <title>{{ title }} | {{ site.title }}</title>
   {% else %}
@@ -18,6 +17,7 @@
     <meta http-equiv="refresh" content="0; URL='{{ external_link }}'">
   {% endif %}
 
+  <link rel="canonical" href="{{ site.url }}{{ page.url | url }}">
 
   {% if site.ga_tracking != nil %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga_tracking }}"></script>

--- a/src/_includes/nav.njk
+++ b/src/_includes/nav.njk
@@ -2,34 +2,13 @@
   role="navigation"
   aria-label="Main navigation"
   id="nav">
-  <ul class="navigation-list">
-    {% set pages_list = collections.all | prepareMenuItems %}
-    {% for node in pages_list %}
-      {% if node.data.parent == nil %}
-        <li class="navigation-list-item{% if page.url == node.page.url %} active{% endif %}">
-          <a href="{{ node.page.url }}" class="navigation-list-link{% if url == node.url %} active{% endif %}">{{ node.data.title }}</a>
-          {% set children_list = collections.all | prepareMenuItems({parentTitle: node.data.title}) %}
-          {% if children_list != blank %}
-            <ul class="navigation-list-child-list ">
-              {% for child in children_list %}
-                <li class="navigation-list-item {% if page.url == child.page.url %} active{% endif %}">
-                  {% if child.data.external_link %}
-                    <a
-                      href="{{ child.data.external_link }}"
-                      class="navigation-list-link"
-                      target="_blank">
-                      {{ child.data.title }}
-                      <img src="/assets/images/external-link-symbol.svg" alt="{{ child.data.title }}" />
-                    </a>
-                  {% else %}
-                    <a href="{{ child.page.url }}" class="navigation-list-link{% if url == child.page.url %} active{% endif %}">{{ child.data.title }}</a>
-                  {% endif %}
-                </li>
-              {% endfor %}
-            </ul>
-          {% endif %}
-        </li>
-      {% endif %}
-    {% endfor %}
-  </ul>
+  {{ collections.all | eleventyNavigation | eleventyNavigationToHtml({
+    listClass: "navigation-list",
+    listItemClass: "navigation-list-item",
+    listItemHasChildrenClass: "has-children",
+    activeListItemClass: "active",
+    anchorClass: "navigation-list-link",
+    activeAnchorClass: "",
+    activeKey: eleventyNavigation.key
+  }) | safe }}
 </nav>

--- a/src/_layouts/default.njk
+++ b/src/_layouts/default.njk
@@ -33,22 +33,13 @@
             {{ content | maybeLoadRemoteReadme({repo_link: repo_link, title: title}) | safe }}
           </article>
           {% endif %}
-          {% if has_children == true and has_toc != false %}
-            {% set children_list = collections.all | prepareMenuItems({parentTitle: title}) %}
-            <ul>
-              {% for child in children_list %}
-                <li>
-                  {% if child.data.external_link %}
-                    <a href="{{ child.data.external_link }}" target="_blank">
-                      {{ child.data.title }} <img src="/assets/images/external-link-symbol.svg" alt="{{ child.data.title }}"/>
-                    </a>
-                  {% else %}
-                    <a href="{{ child.url }}">{{ child.data.title }}</a>
-                  {% endif %}
-                </li>
-              {% endfor %}
-            </ul>
+
+          {% set children = collections.all | eleventyNavigation(eleventyNavigation.key) %}
+          {% if children | length %}
+          <h2>In this Section</h2>
+          {{ children | eleventyNavigationToHtml({listClass: "toc"}) | safe }}
           {% endif %}
+
           <footer class="edit-this-page">
             <p>
               Found a mistake or want to contribute?

--- a/src/docs/api/api.md
+++ b/src/docs/api/api.md
@@ -6,7 +6,6 @@ eleventyNavigation:
   order: 7
 description: Methods and helpers available on the swup instance
 permalink: /api/
-has_toc: true
 ---
 
 # API

--- a/src/docs/api/api.md
+++ b/src/docs/api/api.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: API
+eleventyNavigation:
+  key: API
 description: Methods and helpers available on the swup instance
-has_children: true
-nav_order: 7
 permalink: /api/
 has_toc: true
 ---

--- a/src/docs/api/api.md
+++ b/src/docs/api/api.md
@@ -3,6 +3,7 @@ layout: default
 title: API
 eleventyNavigation:
   key: API
+  order: 7
 description: Methods and helpers available on the swup instance
 permalink: /api/
 has_toc: true

--- a/src/docs/api/cache.md
+++ b/src/docs/api/cache.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Cache
+eleventyNavigation:
+  key: Cache
+  parent: API
 description: Swup's cache and its interface
 nav_order: 2
-parent: API
 permalink: /api/cache/
 ---
 

--- a/src/docs/api/cache.md
+++ b/src/docs/api/cache.md
@@ -4,8 +4,8 @@ title: Cache
 eleventyNavigation:
   key: Cache
   parent: API
+  order: 2
 description: Swup's cache and its interface
-nav_order: 2
 permalink: /api/cache/
 ---
 

--- a/src/docs/api/helpers.md
+++ b/src/docs/api/helpers.md
@@ -4,8 +4,8 @@ title: Helpers
 eleventyNavigation:
   key: Helpers
   parent: API
+  order: 3
 description: Helpers that can be used for developing plugins, themes or anything else around swup
-nav_order: 3
 permalink: /api/helpers/
 ---
 

--- a/src/docs/api/helpers.md
+++ b/src/docs/api/helpers.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Helpers
+eleventyNavigation:
+  key: Helpers
+  parent: API
 description: Helpers that can be used for developing plugins, themes or anything else around swup
 nav_order: 3
-parent: API
 permalink: /api/helpers/
 ---
 

--- a/src/docs/api/methods.md
+++ b/src/docs/api/methods.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Methods
+eleventyNavigation:
+  key: Methods
+  parent: API
 description: Methods on the swup instance
 nav_order: 1
-parent: API
 permalink: /api/methods/
 ---
 

--- a/src/docs/api/methods.md
+++ b/src/docs/api/methods.md
@@ -4,8 +4,8 @@ title: Methods
 eleventyNavigation:
   key: Methods
   parent: API
+  order: 1
 description: Methods on the swup instance
-nav_order: 1
 permalink: /api/methods/
 ---
 

--- a/src/docs/api/variables.md
+++ b/src/docs/api/variables.md
@@ -4,8 +4,8 @@ title: Variables
 eleventyNavigation:
   key: Variables
   parent: API
+  order: 4
 description: A few variables accessible in swup instance that could be helpful
-nav_order: 4
 permalink: /api/variables/
 ---
 

--- a/src/docs/api/variables.md
+++ b/src/docs/api/variables.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Variables
+eleventyNavigation:
+  key: Variables
+  parent: API
 description: A few variables accessible in swup instance that could be helpful
 nav_order: 4
-parent: API
 permalink: /api/variables/
 ---
 

--- a/src/docs/ci-cd/ci-cd.md
+++ b/src/docs/ci-cd/ci-cd.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: CI/CD
+eleventyNavigation:
+  key: CI/CD
 description: You can test your site after each deployment, or as a part of the deploy process
-has_children: true
 nav_order: 8
 permalink: /ci-cd/
 has_toc: false

--- a/src/docs/ci-cd/ci-cd.md
+++ b/src/docs/ci-cd/ci-cd.md
@@ -3,8 +3,8 @@ layout: default
 title: CI/CD
 eleventyNavigation:
   key: CI/CD
+  order: 8
 description: You can test your site after each deployment, or as a part of the deploy process
-nav_order: 8
 permalink: /ci-cd/
 has_toc: false
 ---

--- a/src/docs/ci-cd/ci-cd.md
+++ b/src/docs/ci-cd/ci-cd.md
@@ -6,7 +6,6 @@ eleventyNavigation:
   order: 8
 description: You can test your site after each deployment, or as a part of the deploy process
 permalink: /ci-cd/
-has_toc: false
 ---
 
 # CI/CD

--- a/src/docs/cli/cli.md
+++ b/src/docs/cli/cli.md
@@ -3,7 +3,7 @@ layout: default
 title: CLI
 eleventyNavigation:
   key: CLI
-  order: 8
+  order: 9
 description: Swup handy CLI serves to start creating plugins and themes in a matter of seconds, or validate your site setup
 permalink: /cli/
 has_toc: false

--- a/src/docs/cli/cli.md
+++ b/src/docs/cli/cli.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: CLI
+eleventyNavigation:
+  key: CLI
 description: Swup handy CLI serves to start creating plugins and themes in a matter of seconds, or validate your site setup
-has_children: true
 nav_order: 8
 permalink: /cli/
 has_toc: false

--- a/src/docs/cli/cli.md
+++ b/src/docs/cli/cli.md
@@ -3,8 +3,8 @@ layout: default
 title: CLI
 eleventyNavigation:
   key: CLI
+  order: 8
 description: Swup handy CLI serves to start creating plugins and themes in a matter of seconds, or validate your site setup
-nav_order: 8
 permalink: /cli/
 has_toc: false
 ---

--- a/src/docs/cli/cli.md
+++ b/src/docs/cli/cli.md
@@ -6,7 +6,6 @@ eleventyNavigation:
   order: 9
 description: Swup handy CLI serves to start creating plugins and themes in a matter of seconds, or validate your site setup
 permalink: /cli/
-has_toc: false
 ---
 
 # CLI

--- a/src/docs/events/events.md
+++ b/src/docs/events/events.md
@@ -3,8 +3,8 @@ layout: default
 title: Events
 eleventyNavigation:
   key: Events
+  order: 3
 description: Swup emits bunch of events, that we can use to enable JavaScript, trigger analytics, and much more
-nav_order: 3
 permalink: /events/
 has_toc: false
 ---

--- a/src/docs/events/events.md
+++ b/src/docs/events/events.md
@@ -6,7 +6,6 @@ eleventyNavigation:
   order: 3
 description: Swup emits bunch of events, that we can use to enable JavaScript, trigger analytics, and much more
 permalink: /events/
-has_toc: false
 ---
 
 # Events

--- a/src/docs/events/events.md
+++ b/src/docs/events/events.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Events
+eleventyNavigation:
+  key: Events
 description: Swup emits bunch of events, that we can use to enable JavaScript, trigger analytics, and much more
-has_children: true
 nav_order: 3
 permalink: /events/
 has_toc: false

--- a/src/docs/getting-started/demo.md
+++ b/src/docs/getting-started/demo.md
@@ -4,8 +4,8 @@ title: Demo
 eleventyNavigation:
   key: Demo
   parent: Getting Started
+  order: 4
 description: Here are some demo links
-nav_order: 4
 permalink: /getting-started/demo/
 ---
 

--- a/src/docs/getting-started/demo.md
+++ b/src/docs/getting-started/demo.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Demo
+eleventyNavigation:
+  key: Demo
+  parent: Getting Started
 description: Here are some demo links
-parent: Getting Started
 nav_order: 4
 permalink: /getting-started/demo/
 ---

--- a/src/docs/getting-started/example.md
+++ b/src/docs/getting-started/example.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Example
+eleventyNavigation:
+  key: Example
+  parent: Getting Started
 description: A few steps to get swup working on your site
-parent: Getting Started
 nav_order: 3
 permalink: /getting-started/example/
 ---

--- a/src/docs/getting-started/example.md
+++ b/src/docs/getting-started/example.md
@@ -4,8 +4,8 @@ title: Example
 eleventyNavigation:
   key: Example
   parent: Getting Started
+  order: 3
 description: A few steps to get swup working on your site
-nav_order: 3
 permalink: /getting-started/example/
 ---
 

--- a/src/docs/getting-started/getting-started.md
+++ b/src/docs/getting-started/getting-started.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Getting Started
-has_children: true
+eleventyNavigation:
+  key: Getting Started
 nav_order: 1
 permalink: /getting-started/
 has_toc: false

--- a/src/docs/getting-started/getting-started.md
+++ b/src/docs/getting-started/getting-started.md
@@ -5,7 +5,6 @@ eleventyNavigation:
   key: Getting Started
   order: 1
 permalink: /getting-started/
-has_toc: false
 ---
 
 # Getting Started

--- a/src/docs/getting-started/getting-started.md
+++ b/src/docs/getting-started/getting-started.md
@@ -3,7 +3,7 @@ layout: default
 title: Getting Started
 eleventyNavigation:
   key: Getting Started
-nav_order: 1
+  order: 1
 permalink: /getting-started/
 has_toc: false
 ---

--- a/src/docs/getting-started/how-it-works.md
+++ b/src/docs/getting-started/how-it-works.md
@@ -4,8 +4,8 @@ title: How it works
 eleventyNavigation:
   key: How it works
   parent: Getting Started
+  order: 1
 description: A simple explanation of how swup gets things done
-nav_order: 1
 permalink: /getting-started/how-it-works/
 ---
 

--- a/src/docs/getting-started/how-it-works.md
+++ b/src/docs/getting-started/how-it-works.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: How it works
+eleventyNavigation:
+  key: How it works
+  parent: Getting Started
 description: A simple explanation of how swup gets things done
-parent: Getting Started
 nav_order: 1
 permalink: /getting-started/how-it-works/
 ---

--- a/src/docs/getting-started/installation.md
+++ b/src/docs/getting-started/installation.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Installation
+eleventyNavigation:
+  key: Installation
+  parent: Getting Started
 description: Swup can be installed in few ways
 nav_order: 2
-parent: Getting Started
 permalink: /getting-started/installation/
 ---
 

--- a/src/docs/getting-started/installation.md
+++ b/src/docs/getting-started/installation.md
@@ -4,8 +4,8 @@ title: Installation
 eleventyNavigation:
   key: Installation
   parent: Getting Started
+  order: 2
 description: Swup can be installed in few ways
-nav_order: 2
 permalink: /getting-started/installation/
 ---
 

--- a/src/docs/getting-started/reloading-javascript.md
+++ b/src/docs/getting-started/reloading-javascript.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Reloading Javascript
+eleventyNavigation:
+  key: Reloading Javascript
+  parent: Getting Started
 description: Since swup removes the page reloads from site, it also removes a standard lifecycle of scripts
-parent: Getting Started
 nav_order: 5
 permalink: /getting-started/reloading-javascript/
 ---

--- a/src/docs/getting-started/reloading-javascript.md
+++ b/src/docs/getting-started/reloading-javascript.md
@@ -4,8 +4,8 @@ title: Reloading Javascript
 eleventyNavigation:
   key: Reloading Javascript
   parent: Getting Started
+  order: 5
 description: Since swup removes the page reloads from site, it also removes a standard lifecycle of scripts
-nav_order: 5
 permalink: /getting-started/reloading-javascript/
 ---
 

--- a/src/docs/getting-started/upgrading.md
+++ b/src/docs/getting-started/upgrading.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Upgrading
+eleventyNavigation:
+  key: Upgrading
+  parent: Getting Started
 description: Instructions on upgrading swup in your projects
 nav_order: 7
-parent: Getting Started
 permalink: /getting-started/upgrading/
 ---
 
@@ -15,12 +17,19 @@ Swup 3 is mostly backward-compatible. Most projects should keep running fine aft
 
 ## Contents
 
-- [Multiple CSS transitions](#multiple-css-transitions)
-- [Link selector](#link-selector)
-- [HTML classnames](#html-classnames)
-- [Script import](#script-import)
-- [Helper imports](#helper-imports)
-- [Plugin authors](#plugin-authors)
+- [Upgrading](#upgrading)
+  - [Upgrading from swup 2 to 3](#upgrading-from-swup-2-to-3)
+  - [Contents](#contents)
+    - [Multiple CSS transitions](#multiple-css-transitions)
+    - [Link selector](#link-selector)
+    - [HTML classnames](#html-classnames)
+    - [Script import](#script-import)
+    - [Helper imports](#helper-imports)
+      - [Removed helpers](#removed-helpers)
+    - [Plugin authors](#plugin-authors)
+      - [Update import paths of helpers and utils](#update-import-paths-of-helpers-and-utils)
+      - [Switch to `Location` helper](#switch-to-location-helper)
+      - [Use event delegation helper](#use-event-delegation-helper)
 
 ### Multiple CSS transitions
 

--- a/src/docs/getting-started/upgrading.md
+++ b/src/docs/getting-started/upgrading.md
@@ -4,8 +4,8 @@ title: Upgrading
 eleventyNavigation:
   key: Upgrading
   parent: Getting Started
+  order: 7
 description: Instructions on upgrading swup in your projects
-nav_order: 7
 permalink: /getting-started/upgrading/
 ---
 

--- a/src/docs/getting-started/videos.md
+++ b/src/docs/getting-started/videos.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   order: 6
 description: A few video tutorials by people around the web
 permalink: /getting-started/videos/
-has_toc: false
 ---
 
 # Videos about swup

--- a/src/docs/getting-started/videos.md
+++ b/src/docs/getting-started/videos.md
@@ -1,12 +1,13 @@
 ---
 layout: default
 title: Video tutorials
+eleventyNavigation:
+  key: Video tutorials
+  parent: Getting Started
 description: A few video tutorials by people around the web
-has_children: false
 nav_order: 6
 permalink: /getting-started/videos/
 has_toc: false
-parent: Getting Started
 ---
 
 # Videos about swup

--- a/src/docs/getting-started/videos.md
+++ b/src/docs/getting-started/videos.md
@@ -4,8 +4,8 @@ title: Video tutorials
 eleventyNavigation:
   key: Video tutorials
   parent: Getting Started
+  order: 6
 description: A few video tutorials by people around the web
-nav_order: 6
 permalink: /getting-started/videos/
 has_toc: false
 ---

--- a/src/docs/options/options.md
+++ b/src/docs/options/options.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Options
+eleventyNavigation:
+  key: Options
 description: Swup has a several options that can be passed into a constructor as an object
-has_children: true
 nav_order: 2
 permalink: /options/
 has_toc: false

--- a/src/docs/options/options.md
+++ b/src/docs/options/options.md
@@ -6,7 +6,6 @@ eleventyNavigation:
   order: 2
 description: Swup has a several options that can be passed into a constructor as an object
 permalink: /options/
-has_toc: false
 ---
 
 # Options

--- a/src/docs/options/options.md
+++ b/src/docs/options/options.md
@@ -3,8 +3,8 @@ layout: default
 title: Options
 eleventyNavigation:
   key: Options
+  order: 2
 description: Swup has a several options that can be passed into a constructor as an object
-nav_order: 2
 permalink: /options/
 has_toc: false
 ---

--- a/src/docs/other/browser-support.md
+++ b/src/docs/other/browser-support.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   order: 2
 description:
 permalink: /other/browser-support/
-has_toc: false
 ---
 
 # Browser Support

--- a/src/docs/other/browser-support.md
+++ b/src/docs/other/browser-support.md
@@ -1,12 +1,13 @@
 ---
 layout: default
 title: Browser Support
+eleventyNavigation:
+  key: Browser Support
+  parent: Other
 description:
-has_children: false
 nav_order: 2
 permalink: /other/browser-support/
 has_toc: false
-parent: Other
 ---
 
 # Browser Support

--- a/src/docs/other/browser-support.md
+++ b/src/docs/other/browser-support.md
@@ -4,8 +4,8 @@ title: Browser Support
 eleventyNavigation:
   key: Browser Support
   parent: Other
+  order: 2
 description:
-nav_order: 2
 permalink: /other/browser-support/
 has_toc: false
 ---

--- a/src/docs/other/changelog.md
+++ b/src/docs/other/changelog.md
@@ -4,7 +4,7 @@ title: Changelog
 eleventyNavigation:
   key: Changelog
   parent: Other
-nav_order: 4
+  order: 4
 has_toc: false
 external_link: https://github.com/swup/swup/blob/master/CHANGELOG.md
 ---

--- a/src/docs/other/changelog.md
+++ b/src/docs/other/changelog.md
@@ -1,9 +1,10 @@
 ---
 layout: default
 title: Changelog
-has_children: false
+eleventyNavigation:
+  key: Changelog
+  parent: Other
 nav_order: 4
 has_toc: false
-parent: Other
 external_link: https://github.com/swup/swup/blob/master/CHANGELOG.md
 ---

--- a/src/docs/other/changelog.md
+++ b/src/docs/other/changelog.md
@@ -5,6 +5,7 @@ eleventyNavigation:
   key: Changelog
   parent: Other
   order: 4
+  url: https://github.com/swup/swup/blob/master/CHANGELOG.md
 has_toc: false
-external_link: https://github.com/swup/swup/blob/master/CHANGELOG.md
+permalink: false
 ---

--- a/src/docs/other/changelog.md
+++ b/src/docs/other/changelog.md
@@ -6,6 +6,5 @@ eleventyNavigation:
   parent: Other
   order: 4
   url: https://github.com/swup/swup/blob/master/CHANGELOG.md
-has_toc: false
 permalink: false
 ---

--- a/src/docs/other/common-issues.md
+++ b/src/docs/other/common-issues.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   order: 1
 description: Description of common issue or caveats people encounter
 permalink: /other/common-issues/
-has_toc: false
 ---
 
 # Common Issues

--- a/src/docs/other/common-issues.md
+++ b/src/docs/other/common-issues.md
@@ -4,8 +4,8 @@ title: Common Issues
 eleventyNavigation:
   key: Common Issues
   parent: Other
+  order: 1
 description: Description of common issue or caveats people encounter
-nav_order: 1
 permalink: /other/common-issues/
 has_toc: false
 ---

--- a/src/docs/other/common-issues.md
+++ b/src/docs/other/common-issues.md
@@ -1,12 +1,13 @@
 ---
 layout: default
 title: Common Issues
+eleventyNavigation:
+  key: Common Issues
+  parent: Other
 description: Description of common issue or caveats people encounter
-has_children: false
 nav_order: 1
 permalink: /other/common-issues/
 has_toc: false
-parent: Other
 ---
 
 # Common Issues

--- a/src/docs/other/contributions.md
+++ b/src/docs/other/contributions.md
@@ -21,7 +21,7 @@ If you have a question, suggestion, or feature request, feel free to
 
 ## Pull Requests
 
-If you would like to see a new feature in swup, we encourage you to fork swup and create a [pull request](<[url](https://github.com/swup/swup/pulls)>)!
+If you would like to see a new feature in swup, we encourage you to fork swup and create a [pull request](https://github.com/swup/swup/pulls)!
 
 Please make sure to run the swup tests locally before creating your PR on GitHub:
 

--- a/src/docs/other/contributions.md
+++ b/src/docs/other/contributions.md
@@ -21,7 +21,7 @@ If you have a question, suggestion, or feature request, feel free to
 
 ## Pull Requests
 
-If you would like to see a new feature in swup, we encourage you to fork swup and create a [pull request](https://github.com/swup/swup/pulls)!
+If you would like to see a new feature in swup, we encourage you to fork swup and create a [pull request](<[url](https://github.com/swup/swup/pulls)>)!
 
 Please make sure to run the swup tests locally before creating your PR on GitHub:
 

--- a/src/docs/other/contributions.md
+++ b/src/docs/other/contributions.md
@@ -4,8 +4,8 @@ title: Contributions
 eleventyNavigation:
   key: Contributions
   parent: Other
+  order: 3
 description: How to contribute to swup's development
-nav_order: 3
 permalink: /other/contributions/
 has_toc: false
 ---

--- a/src/docs/other/contributions.md
+++ b/src/docs/other/contributions.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   order: 3
 description: How to contribute to swup's development
 permalink: /other/contributions/
-has_toc: false
 ---
 
 # Contributions

--- a/src/docs/other/contributions.md
+++ b/src/docs/other/contributions.md
@@ -1,12 +1,13 @@
 ---
 layout: default
 title: Contributions
+eleventyNavigation:
+  key: Contributions
+  parent: Other
 description: How to contribute to swup's development
-has_children: false
 nav_order: 3
 permalink: /other/contributions/
 has_toc: false
-parent: Other
 ---
 
 # Contributions

--- a/src/docs/other/discussions.md
+++ b/src/docs/other/discussions.md
@@ -1,9 +1,10 @@
 ---
 layout: default
 title: Discussions
-has_children: false
+eleventyNavigation:
+  key: Discussions
+  parent: Other
 nav_order: 7
 has_toc: false
-parent: Other
 external_link: https://github.com/swup/swup/discussions
 ---

--- a/src/docs/other/discussions.md
+++ b/src/docs/other/discussions.md
@@ -4,7 +4,7 @@ title: Discussions
 eleventyNavigation:
   key: Discussions
   parent: Other
-nav_order: 7
+  order: 7
 has_toc: false
 external_link: https://github.com/swup/swup/discussions
 ---

--- a/src/docs/other/discussions.md
+++ b/src/docs/other/discussions.md
@@ -5,6 +5,7 @@ eleventyNavigation:
   key: Discussions
   parent: Other
   order: 7
+  url: https://github.com/swup/swup/discussions
 has_toc: false
-external_link: https://github.com/swup/swup/discussions
+permalink: false
 ---

--- a/src/docs/other/discussions.md
+++ b/src/docs/other/discussions.md
@@ -6,6 +6,5 @@ eleventyNavigation:
   parent: Other
   order: 7
   url: https://github.com/swup/swup/discussions
-has_toc: false
 permalink: false
 ---

--- a/src/docs/other/other.md
+++ b/src/docs/other/other.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Other
+eleventyNavigation:
+  key: Other
 description: Some more stuff about swup
-has_children: true
 nav_order: 10
 permalink: /other/
 has_toc: true

--- a/src/docs/other/other.md
+++ b/src/docs/other/other.md
@@ -6,7 +6,6 @@ eleventyNavigation:
   order: 10
 description: Some more stuff about swup
 permalink: /other/
-has_toc: true
 ---
 
 # More stuff about swup

--- a/src/docs/other/other.md
+++ b/src/docs/other/other.md
@@ -3,8 +3,8 @@ layout: default
 title: Other
 eleventyNavigation:
   key: Other
+  order: 10
 description: Some more stuff about swup
-nav_order: 10
 permalink: /other/
 has_toc: true
 ---

--- a/src/docs/other/swup-repositories.md
+++ b/src/docs/other/swup-repositories.md
@@ -1,9 +1,10 @@
 ---
 layout: default
 title: Swup repositories
-has_children: false
+eleventyNavigation:
+  key: Swup repositories
+  parent: Other
 nav_order: 6
 has_toc: false
-parent: Other
 external_link: https://github.com/swup
 ---

--- a/src/docs/other/swup-repositories.md
+++ b/src/docs/other/swup-repositories.md
@@ -4,7 +4,7 @@ title: Swup repositories
 eleventyNavigation:
   key: Swup repositories
   parent: Other
-nav_order: 6
+  order: 6
 has_toc: false
 external_link: https://github.com/swup
 ---

--- a/src/docs/other/swup-repositories.md
+++ b/src/docs/other/swup-repositories.md
@@ -6,6 +6,5 @@ eleventyNavigation:
   parent: Other
   order: 6
   url: https://github.com/swup
-has_toc: false
 permalink: false
 ---

--- a/src/docs/other/swup-repositories.md
+++ b/src/docs/other/swup-repositories.md
@@ -5,6 +5,7 @@ eleventyNavigation:
   key: Swup repositories
   parent: Other
   order: 6
+  url: https://github.com/swup
 has_toc: false
-external_link: https://github.com/swup
+permalink: false
 ---

--- a/src/docs/other/swup-usage-examples.md
+++ b/src/docs/other/swup-usage-examples.md
@@ -6,6 +6,5 @@ eleventyNavigation:
   parent: Other
   order: 5
   url: https://github.com/swup/swup/discussions/333
-has_toc: false
 permalink: false
 ---

--- a/src/docs/other/swup-usage-examples.md
+++ b/src/docs/other/swup-usage-examples.md
@@ -1,9 +1,10 @@
 ---
 layout: default
 title: Sites using swup
-has_children: false
+eleventyNavigation:
+  key: Sites using swup
+  parent: Other
 nav_order: 5
 has_toc: false
-parent: Other
 external_link: https://github.com/swup/swup/discussions/333
 ---

--- a/src/docs/other/swup-usage-examples.md
+++ b/src/docs/other/swup-usage-examples.md
@@ -4,7 +4,7 @@ title: Sites using swup
 eleventyNavigation:
   key: Sites using swup
   parent: Other
-nav_order: 5
+  order: 5
 has_toc: false
 external_link: https://github.com/swup/swup/discussions/333
 ---

--- a/src/docs/other/swup-usage-examples.md
+++ b/src/docs/other/swup-usage-examples.md
@@ -5,6 +5,7 @@ eleventyNavigation:
   key: Sites using swup
   parent: Other
   order: 5
+  url: https://github.com/swup/swup/discussions/333
 has_toc: false
-external_link: https://github.com/swup/swup/discussions/333
+permalink: false
 ---

--- a/src/docs/plugins/a11y-plugin.md
+++ b/src/docs/plugins/a11y-plugin.md
@@ -1,11 +1,13 @@
 ---
 layout: default
 title: Accessibility Plugin
+eleventyNavigation:
+  key: Accessibility Plugin
+  parent: Plugins
 description: Plugin to enhanced accessibility
-parent: Plugins
 nav_order: 1
 permalink: /plugins/a11y-plugin/
 repo_link: https://github.com/swup/a11y-plugin/
 ---
 
-⚠️ This page content is loaded from the repository README.md file. Edit the file in the source repository. 
+⚠️ This page content is loaded from the repository README.md file. Edit the file in the source repository.

--- a/src/docs/plugins/a11y-plugin.md
+++ b/src/docs/plugins/a11y-plugin.md
@@ -4,8 +4,8 @@ title: Accessibility Plugin
 eleventyNavigation:
   key: Accessibility Plugin
   parent: Plugins
+  order: 1
 description: Plugin to enhanced accessibility
-nav_order: 1
 permalink: /plugins/a11y-plugin/
 repo_link: https://github.com/swup/a11y-plugin/
 ---

--- a/src/docs/plugins/body-class-plugin.md
+++ b/src/docs/plugins/body-class-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Body Class Plugin
+eleventyNavigation:
+  key: Body Class Plugin
+  parent: Plugins
 description: Plugin to replace body classes for each loaded page
-parent: Plugins
 nav_order: 2
 permalink: /plugins/body-class-plugin/
 repo_link: https://github.com/swup/body-class-plugin

--- a/src/docs/plugins/body-class-plugin.md
+++ b/src/docs/plugins/body-class-plugin.md
@@ -4,8 +4,8 @@ title: Body Class Plugin
 eleventyNavigation:
   key: Body Class Plugin
   parent: Plugins
+  order: 2
 description: Plugin to replace body classes for each loaded page
-nav_order: 2
 permalink: /plugins/body-class-plugin/
 repo_link: https://github.com/swup/body-class-plugin
 ---

--- a/src/docs/plugins/create-plugin.md
+++ b/src/docs/plugins/create-plugin.md
@@ -4,8 +4,8 @@ title: Create Plugin 🎉
 eleventyNavigation:
   key: Create Plugin 🎉
   parent: Plugins
+  order: 100
 description: Create your own plugin
-nav_order: 100
 permalink: /plugins/create-plugin/
 ---
 

--- a/src/docs/plugins/create-plugin.md
+++ b/src/docs/plugins/create-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Create Plugin 🎉
+eleventyNavigation:
+  key: Create Plugin 🎉
+  parent: Plugins
 description: Create your own plugin
-parent: Plugins
 nav_order: 100
 permalink: /plugins/create-plugin/
 ---

--- a/src/docs/plugins/custom-payload-plugin.md
+++ b/src/docs/plugins/custom-payload-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Custom Payload Plugin
+eleventyNavigation:
+  key: Custom Payload Plugin
+  parent: Plugins
 description: Plugin to allow receiving of custom payload formats from the server
-parent: Plugins
 nav_order: 4
 permalink: /plugins/custom-payload-plugin/
 repo_link: https://github.com/swup/custom-payload-plugin

--- a/src/docs/plugins/custom-payload-plugin.md
+++ b/src/docs/plugins/custom-payload-plugin.md
@@ -4,8 +4,8 @@ title: Custom Payload Plugin
 eleventyNavigation:
   key: Custom Payload Plugin
   parent: Plugins
+  order: 4
 description: Plugin to allow receiving of custom payload formats from the server
-nav_order: 4
 permalink: /plugins/custom-payload-plugin/
 repo_link: https://github.com/swup/custom-payload-plugin
 ---

--- a/src/docs/plugins/debug-plugin.md
+++ b/src/docs/plugins/debug-plugin.md
@@ -4,8 +4,8 @@ title: Debug Plugin
 eleventyNavigation:
   key: Debug Plugin
   parent: Plugins
+  order: 5
 description: Plugin to display debug information and tips
-nav_order: 5
 permalink: /plugins/debug-plugin/
 repo_link: https://github.com/swup/debug-plugin
 ---

--- a/src/docs/plugins/debug-plugin.md
+++ b/src/docs/plugins/debug-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Debug Plugin
+eleventyNavigation:
+  key: Debug Plugin
+  parent: Plugins
 description: Plugin to display debug information and tips
-parent: Plugins
 nav_order: 5
 permalink: /plugins/debug-plugin/
 repo_link: https://github.com/swup/debug-plugin

--- a/src/docs/plugins/forms-plugin.md
+++ b/src/docs/plugins/forms-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Forms Plugin
+eleventyNavigation:
+  key: Forms Plugin
+  parent: Plugins
 description: Plugin to submit forms with transitions
-parent: Plugins
 nav_order: 6
 permalink: /plugins/forms-plugin/
 repo_link: https://github.com/swup/forms-plugin

--- a/src/docs/plugins/forms-plugin.md
+++ b/src/docs/plugins/forms-plugin.md
@@ -4,8 +4,8 @@ title: Forms Plugin
 eleventyNavigation:
   key: Forms Plugin
   parent: Plugins
+  order: 6
 description: Plugin to submit forms with transitions
-nav_order: 6
 permalink: /plugins/forms-plugin/
 repo_link: https://github.com/swup/forms-plugin
 ---

--- a/src/docs/plugins/ga-plugin.md
+++ b/src/docs/plugins/ga-plugin.md
@@ -4,8 +4,8 @@ title: GA Plugin
 eleventyNavigation:
   key: GA Plugin
   parent: Plugins
+  order: 7
 description: Plugin to trigger GA page views
-nav_order: 7
 permalink: /plugins/google-analytics-plugin/
 repo_link: https://github.com/swup/ga-plugin
 ---

--- a/src/docs/plugins/ga-plugin.md
+++ b/src/docs/plugins/ga-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: GA Plugin
+eleventyNavigation:
+  key: GA Plugin
+  parent: Plugins
 description: Plugin to trigger GA page views
-parent: Plugins
 nav_order: 7
 permalink: /plugins/google-analytics-plugin/
 repo_link: https://github.com/swup/ga-plugin

--- a/src/docs/plugins/gia-plugin.md
+++ b/src/docs/plugins/gia-plugin.md
@@ -4,8 +4,8 @@ title: Gia Plugin
 eleventyNavigation:
   key: Gia Plugin
   parent: Plugins
+  order: 8
 description: Plugin to enable Gia components in swup containers
-nav_order: 8
 permalink: /plugins/gia-plugin/
 repo_link: https://github.com/swup/gia-plugin
 ---

--- a/src/docs/plugins/gia-plugin.md
+++ b/src/docs/plugins/gia-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Gia Plugin
+eleventyNavigation:
+  key: Gia Plugin
+  parent: Plugins
 description: Plugin to enable Gia components in swup containers
-parent: Plugins
 nav_order: 8
 permalink: /plugins/gia-plugin/
 repo_link: https://github.com/swup/gia-plugin

--- a/src/docs/plugins/gtm-plugin.md
+++ b/src/docs/plugins/gtm-plugin.md
@@ -4,8 +4,8 @@ title: GTM Plugin
 eleventyNavigation:
   key: GTM Plugin
   parent: Plugins
+  order: 9
 description: Plugin to trigger GTM page view events
-nav_order: 9
 permalink: /plugins/google-tag-manager-plugin/
 repo_link: https://github.com/swup/gtm-plugin
 ---

--- a/src/docs/plugins/gtm-plugin.md
+++ b/src/docs/plugins/gtm-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: GTM Plugin
+eleventyNavigation:
+  key: GTM Plugin
+  parent: Plugins
 description: Plugin to trigger GTM page view events
-parent: Plugins
 nav_order: 9
 permalink: /plugins/google-tag-manager-plugin/
 repo_link: https://github.com/swup/gtm-plugin

--- a/src/docs/plugins/head-plugin.md
+++ b/src/docs/plugins/head-plugin.md
@@ -4,8 +4,8 @@ title: Head Plugin
 eleventyNavigation:
   key: Head Plugin
   parent: Plugins
+  order: 10
 description: Plugin to replace tags in the head tag
-nav_order: 10
 permalink: /plugins/head-plugin/
 repo_link: https://github.com/swup/head-plugin
 ---

--- a/src/docs/plugins/head-plugin.md
+++ b/src/docs/plugins/head-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Head Plugin
+eleventyNavigation:
+  key: Head Plugin
+  parent: Plugins
 description: Plugin to replace tags in the head tag
-parent: Plugins
 nav_order: 10
 permalink: /plugins/head-plugin/
 repo_link: https://github.com/swup/head-plugin

--- a/src/docs/plugins/js-plugin.md
+++ b/src/docs/plugins/js-plugin.md
@@ -4,8 +4,8 @@ title: JS Plugin
 eleventyNavigation:
   key: JS Plugin
   parent: Plugins
+  order: 11
 description: Plugin to use JS animations instead of CSS
-nav_order: 11
 permalink: /plugins/js-plugin/
 repo_link: https://github.com/swup/js-plugin
 ---

--- a/src/docs/plugins/js-plugin.md
+++ b/src/docs/plugins/js-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: JS Plugin
+eleventyNavigation:
+  key: JS Plugin
+  parent: Plugins
 description: Plugin to use JS animations instead of CSS
-parent: Plugins
 nav_order: 11
 permalink: /plugins/js-plugin/
 repo_link: https://github.com/swup/js-plugin

--- a/src/docs/plugins/livewire-plugin.md
+++ b/src/docs/plugins/livewire-plugin.md
@@ -4,8 +4,8 @@ title: Laravel Livewire Plugin
 eleventyNavigation:
   key: Laravel Livewire Plugin
   parent: Plugins
+  order: 12
 description: Plguin to refresh Livewire components after swup page transition
-nav_order: 12
 permalink: /plugins/livewire-plugin/
 repo_link: https://github.com/swup/livewire-plugin
 ---

--- a/src/docs/plugins/livewire-plugin.md
+++ b/src/docs/plugins/livewire-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Laravel Livewire Plugin
+eleventyNavigation:
+  key: Laravel Livewire Plugin
+  parent: Plugins
 description: Plguin to refresh Livewire components after swup page transition
-parent: Plugins
 nav_order: 12
 permalink: /plugins/livewire-plugin/
 repo_link: https://github.com/swup/livewire-plugin

--- a/src/docs/plugins/matomo-plugin.md
+++ b/src/docs/plugins/matomo-plugin.md
@@ -4,8 +4,8 @@ title: Matomo Plugin
 eleventyNavigation:
   key: Matomo Plugin
   parent: Plugins
+  order: 12
 description: Plugin to trigger Matomo page views
-nav_order: 12
 permalink: /plugins/matomo-plugin/
 repo_link: https://github.com/swup/matomo-plugin
 ---

--- a/src/docs/plugins/matomo-plugin.md
+++ b/src/docs/plugins/matomo-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Matomo Plugin
+eleventyNavigation:
+  key: Matomo Plugin
+  parent: Plugins
 description: Plugin to trigger Matomo page views
-parent: Plugins
 nav_order: 12
 permalink: /plugins/matomo-plugin/
 repo_link: https://github.com/swup/matomo-plugin

--- a/src/docs/plugins/plugins.md
+++ b/src/docs/plugins/plugins.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Plugins
+eleventyNavigation:
+  key: Plugins
 description: List of available official plugins
-has_children: true
 nav_order: 4
 permalink: /plugins/
 has_toc: false

--- a/src/docs/plugins/plugins.md
+++ b/src/docs/plugins/plugins.md
@@ -3,8 +3,8 @@ layout: default
 title: Plugins
 eleventyNavigation:
   key: Plugins
+  order: 4
 description: List of available official plugins
-nav_order: 4
 permalink: /plugins/
 has_toc: false
 ---

--- a/src/docs/plugins/plugins.md
+++ b/src/docs/plugins/plugins.md
@@ -6,7 +6,6 @@ eleventyNavigation:
   order: 4
 description: List of available official plugins
 permalink: /plugins/
-has_toc: false
 ---
 
 # Plugins

--- a/src/docs/plugins/preload-plugin.md
+++ b/src/docs/plugins/preload-plugin.md
@@ -4,8 +4,8 @@ title: Preload Plugin
 eleventyNavigation:
   key: Preload Plugin
   parent: Plugins
+  order: 13
 description: Plugin to preload pages ahead of time
-nav_order: 13
 permalink: /plugins/preload-plugin/
 repo_link: https://github.com/swup/preload-plugin
 ---

--- a/src/docs/plugins/preload-plugin.md
+++ b/src/docs/plugins/preload-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Preload Plugin
+eleventyNavigation:
+  key: Preload Plugin
+  parent: Plugins
 description: Plugin to preload pages ahead of time
-parent: Plugins
 nav_order: 13
 permalink: /plugins/preload-plugin/
 repo_link: https://github.com/swup/preload-plugin

--- a/src/docs/plugins/progress-plugin.md
+++ b/src/docs/plugins/progress-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Progress Bar Plugin
+eleventyNavigation:
+  key: Progress Bar Plugin
+  parent: Plugins
 description: Plugin for displaying a loading indicator
-parent: Plugins
 nav_order: 14
 permalink: /plugins/progress-plugin/
 repo_link: https://github.com/swup/progress-plugin

--- a/src/docs/plugins/progress-plugin.md
+++ b/src/docs/plugins/progress-plugin.md
@@ -4,8 +4,8 @@ title: Progress Bar Plugin
 eleventyNavigation:
   key: Progress Bar Plugin
   parent: Plugins
+  order: 14
 description: Plugin for displaying a loading indicator
-nav_order: 14
 permalink: /plugins/progress-plugin/
 repo_link: https://github.com/swup/progress-plugin
 ---

--- a/src/docs/plugins/route-name-plugin.md
+++ b/src/docs/plugins/route-name-plugin.md
@@ -4,8 +4,8 @@ title: Route Name Plugin
 eleventyNavigation:
   key: Route Name Plugin
   parent: Plugins
+  order: 15
 description: Plugin to use named routes for choosing animations
-nav_order: 15
 permalink: /plugins/route-name-plugin/
 repo_link: https://github.com/swup/route-name-plugin
 ---

--- a/src/docs/plugins/route-name-plugin.md
+++ b/src/docs/plugins/route-name-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Route Name Plugin
+eleventyNavigation:
+  key: Route Name Plugin
+  parent: Plugins
 description: Plugin to use named routes for choosing animations
-parent: Plugins
 nav_order: 15
 permalink: /plugins/route-name-plugin/
 repo_link: https://github.com/swup/route-name-plugin

--- a/src/docs/plugins/scripts-plugin.md
+++ b/src/docs/plugins/scripts-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Scripts Plugin
+eleventyNavigation:
+  key: Scripts Plugin
+  parent: Plugins
 description: Plugin to re-run scripts on the page on each page transition
-parent: Plugins
 nav_order: 16
 permalink: /plugins/scripts-plugin/
 repo_link: https://github.com/swup/scripts-plugin

--- a/src/docs/plugins/scripts-plugin.md
+++ b/src/docs/plugins/scripts-plugin.md
@@ -4,8 +4,8 @@ title: Scripts Plugin
 eleventyNavigation:
   key: Scripts Plugin
   parent: Plugins
+  order: 16
 description: Plugin to re-run scripts on the page on each page transition
-nav_order: 16
 permalink: /plugins/scripts-plugin/
 repo_link: https://github.com/swup/scripts-plugin
 ---

--- a/src/docs/plugins/scroll-plugin.md
+++ b/src/docs/plugins/scroll-plugin.md
@@ -4,8 +4,8 @@ title: Scroll Plugin
 eleventyNavigation:
   key: Scroll Plugin
   parent: Plugins
+  order: 17
 description: Plugin to control scroll position of the page
-nav_order: 17
 permalink: /plugins/scroll-plugin/
 repo_link: https://github.com/swup/scroll-plugin
 ---

--- a/src/docs/plugins/scroll-plugin.md
+++ b/src/docs/plugins/scroll-plugin.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Scroll Plugin
+eleventyNavigation:
+  key: Scroll Plugin
+  parent: Plugins
 description: Plugin to control scroll position of the page
-parent: Plugins
 nav_order: 17
 permalink: /plugins/scroll-plugin/
 repo_link: https://github.com/swup/scroll-plugin

--- a/src/docs/themes/create-theme.md
+++ b/src/docs/themes/create-theme.md
@@ -4,8 +4,8 @@ title: Create Theme 🎉
 eleventyNavigation:
   key: Create Theme 🎉
   parent: Themes
+  order: 4
 description: Create your own theme
-nav_order: 4
 permalink: https://github.com/swup/themes/create-theme/
 ---
 

--- a/src/docs/themes/create-theme.md
+++ b/src/docs/themes/create-theme.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Create Theme 🎉
+eleventyNavigation:
+  key: Create Theme 🎉
+  parent: Themes
 description: Create your own theme
-parent: Themes
 nav_order: 4
 permalink: https://github.com/swup/themes/create-theme/
 ---

--- a/src/docs/themes/create-theme.md
+++ b/src/docs/themes/create-theme.md
@@ -6,7 +6,7 @@ eleventyNavigation:
   parent: Themes
   order: 4
 description: Create your own theme
-permalink: https://github.com/swup/themes/create-theme/
+permalink: /themes/create-theme/
 ---
 
 # Create Theme

--- a/src/docs/themes/fade-theme.md
+++ b/src/docs/themes/fade-theme.md
@@ -4,8 +4,8 @@ title: Fade Theme
 eleventyNavigation:
   key: Fade Theme
   parent: Themes
+  order: 1
 description: Theme to fade pages on the transition
-nav_order: 1
 permalink: /themes/fade-theme/
 repo_link: https://github.com/swup/fade-theme
 ---

--- a/src/docs/themes/fade-theme.md
+++ b/src/docs/themes/fade-theme.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Fade Theme
+eleventyNavigation:
+  key: Fade Theme
+  parent: Themes
 description: Theme to fade pages on the transition
-parent: Themes
 nav_order: 1
 permalink: /themes/fade-theme/
 repo_link: https://github.com/swup/fade-theme

--- a/src/docs/themes/overlay-theme.md
+++ b/src/docs/themes/overlay-theme.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Overlay Theme
+eleventyNavigation:
+  key: Overlay Theme
+  parent: Themes
 description: Theme to hide pages behind overlay on the transition
-parent: Themes
 nav_order: 3
 permalink: /themes/overlay-theme/
 repo_link: https://github.com/swup/overlay-theme

--- a/src/docs/themes/overlay-theme.md
+++ b/src/docs/themes/overlay-theme.md
@@ -4,8 +4,8 @@ title: Overlay Theme
 eleventyNavigation:
   key: Overlay Theme
   parent: Themes
+  order: 3
 description: Theme to hide pages behind overlay on the transition
-nav_order: 3
 permalink: /themes/overlay-theme/
 repo_link: https://github.com/swup/overlay-theme
 ---

--- a/src/docs/themes/slide-theme.md
+++ b/src/docs/themes/slide-theme.md
@@ -4,8 +4,8 @@ title: Slide Theme
 eleventyNavigation:
   key: Slide Theme
   parent: Themes
+  order: 2
 description: Theme to slide and fade pages on the transition
-nav_order: 2
 permalink: /themes/slide-theme/
 repo_link: https://github.com/swup/slide-theme
 ---

--- a/src/docs/themes/slide-theme.md
+++ b/src/docs/themes/slide-theme.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Slide Theme
+eleventyNavigation:
+  key: Slide Theme
+  parent: Themes
 description: Theme to slide and fade pages on the transition
-parent: Themes
 nav_order: 2
 permalink: /themes/slide-theme/
 repo_link: https://github.com/swup/slide-theme

--- a/src/docs/themes/themes.md
+++ b/src/docs/themes/themes.md
@@ -6,7 +6,6 @@ eleventyNavigation:
   order: 5
 description: List of official themes
 permalink: /themes/
-has_toc: true
 ---
 
 # Themes

--- a/src/docs/themes/themes.md
+++ b/src/docs/themes/themes.md
@@ -3,8 +3,8 @@ layout: default
 title: Themes
 eleventyNavigation:
   key: Themes
+  order: 5
 description: List of official themes
-nav_order: 5
 permalink: /themes/
 has_toc: true
 ---

--- a/src/docs/themes/themes.md
+++ b/src/docs/themes/themes.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Themes
+eleventyNavigation:
+  key: Themes
 description: List of official themes
-has_children: true
 nav_order: 5
 permalink: /themes/
 has_toc: true

--- a/src/docs/third-party-integrations/gtag-plugin.md
+++ b/src/docs/third-party-integrations/gtag-plugin.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 title: GTAG Plugin
-parent: 3rd Party Integrations
+eleventyNavigation:
+  key: GTAG Plugin
+  parent: 3rd Party Integrations
 nav_order: 1
 external_link: https://github.com/joshuaHallee/swup-gtag-plugin
 ---

--- a/src/docs/third-party-integrations/gtag-plugin.md
+++ b/src/docs/third-party-integrations/gtag-plugin.md
@@ -5,5 +5,6 @@ eleventyNavigation:
   key: GTAG Plugin
   parent: 3rd Party Integrations
   order: 1
-external_link: https://github.com/joshuaHallee/swup-gtag-plugin
+  url: https://github.com/joshuaHallee/swup-gtag-plugin
+permalink: false
 ---

--- a/src/docs/third-party-integrations/gtag-plugin.md
+++ b/src/docs/third-party-integrations/gtag-plugin.md
@@ -4,6 +4,6 @@ title: GTAG Plugin
 eleventyNavigation:
   key: GTAG Plugin
   parent: 3rd Party Integrations
-nav_order: 1
+  order: 1
 external_link: https://github.com/joshuaHallee/swup-gtag-plugin
 ---

--- a/src/docs/third-party-integrations/html-lang-plugin.md
+++ b/src/docs/third-party-integrations/html-lang-plugin.md
@@ -5,5 +5,6 @@ eleventyNavigation:
   key: HTML Lang Plugin
   parent: 3rd Party Integrations
   order: 3
-external_link: https://github.com/mashvp/swup-html-lang-plugin
+  url: https://github.com/mashvp/swup-html-lang-plugin
+permalink: false
 ---

--- a/src/docs/third-party-integrations/html-lang-plugin.md
+++ b/src/docs/third-party-integrations/html-lang-plugin.md
@@ -4,6 +4,6 @@ title: HTML Lang Plugin
 eleventyNavigation:
   key: HTML Lang Plugin
   parent: 3rd Party Integrations
-nav_order: 3
+  order: 3
 external_link: https://github.com/mashvp/swup-html-lang-plugin
 ---

--- a/src/docs/third-party-integrations/html-lang-plugin.md
+++ b/src/docs/third-party-integrations/html-lang-plugin.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 title: HTML Lang Plugin
-parent: 3rd Party Integrations
+eleventyNavigation:
+  key: HTML Lang Plugin
+  parent: 3rd Party Integrations
 nav_order: 3
 external_link: https://github.com/mashvp/swup-html-lang-plugin
 ---

--- a/src/docs/third-party-integrations/morph-plugin.md
+++ b/src/docs/third-party-integrations/morph-plugin.md
@@ -4,6 +4,6 @@ title: Morph Plugin
 eleventyNavigation:
   key: Morph Plugin
   parent: 3rd Party Integrations
-nav_order: 4
+  order: 4
 external_link: https://github.com/daun/swup-morph-plugin
 ---

--- a/src/docs/third-party-integrations/morph-plugin.md
+++ b/src/docs/third-party-integrations/morph-plugin.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 title: Morph Plugin
-parent: 3rd Party Integrations
+eleventyNavigation:
+  key: Morph Plugin
+  parent: 3rd Party Integrations
 nav_order: 4
 external_link: https://github.com/daun/swup-morph-plugin
 ---

--- a/src/docs/third-party-integrations/morph-plugin.md
+++ b/src/docs/third-party-integrations/morph-plugin.md
@@ -5,5 +5,6 @@ eleventyNavigation:
   key: Morph Plugin
   parent: 3rd Party Integrations
   order: 4
-external_link: https://github.com/daun/swup-morph-plugin
+  url: https://github.com/daun/swup-morph-plugin
+permalink: false
 ---

--- a/src/docs/third-party-integrations/preserve-scroll-plugin.md
+++ b/src/docs/third-party-integrations/preserve-scroll-plugin.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 title: Preserve Scroll Plugin
-parent: 3rd Party Integrations
+eleventyNavigation:
+  key: Preserve Scroll Plugin
+  parent: 3rd Party Integrations
 nav_order: 2
 external_link: https://github.com/ngsctt/SwupPreserveScrollPlugin
 ---

--- a/src/docs/third-party-integrations/preserve-scroll-plugin.md
+++ b/src/docs/third-party-integrations/preserve-scroll-plugin.md
@@ -4,6 +4,6 @@ title: Preserve Scroll Plugin
 eleventyNavigation:
   key: Preserve Scroll Plugin
   parent: 3rd Party Integrations
-nav_order: 2
+  order: 2
 external_link: https://github.com/ngsctt/SwupPreserveScrollPlugin
 ---

--- a/src/docs/third-party-integrations/preserve-scroll-plugin.md
+++ b/src/docs/third-party-integrations/preserve-scroll-plugin.md
@@ -5,5 +5,6 @@ eleventyNavigation:
   key: Preserve Scroll Plugin
   parent: 3rd Party Integrations
   order: 2
-external_link: https://github.com/ngsctt/SwupPreserveScrollPlugin
+  url: https://github.com/ngsctt/SwupPreserveScrollPlugin
+permalink: false
 ---

--- a/src/docs/third-party-integrations/swup-meta-tags-plugin.md
+++ b/src/docs/third-party-integrations/swup-meta-tags-plugin.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 title: Meta Tags Plugin
-parent: 3rd Party Integrations
+eleventyNavigation:
+  key: Meta Tags Plugin
+  parent: 3rd Party Integrations
 nav_order: 5
 external_link: https://github.com/Accudio/swup-meta-tags-plugin
 ---

--- a/src/docs/third-party-integrations/swup-meta-tags-plugin.md
+++ b/src/docs/third-party-integrations/swup-meta-tags-plugin.md
@@ -4,6 +4,6 @@ title: Meta Tags Plugin
 eleventyNavigation:
   key: Meta Tags Plugin
   parent: 3rd Party Integrations
-nav_order: 5
+  order: 5
 external_link: https://github.com/Accudio/swup-meta-tags-plugin
 ---

--- a/src/docs/third-party-integrations/swup-meta-tags-plugin.md
+++ b/src/docs/third-party-integrations/swup-meta-tags-plugin.md
@@ -5,5 +5,6 @@ eleventyNavigation:
   key: Meta Tags Plugin
   parent: 3rd Party Integrations
   order: 5
-external_link: https://github.com/Accudio/swup-meta-tags-plugin
+  url: https://github.com/Accudio/swup-meta-tags-plugin
+permlink: false
 ---

--- a/src/docs/third-party-integrations/third-party-integrations.md
+++ b/src/docs/third-party-integrations/third-party-integrations.md
@@ -6,7 +6,6 @@ eleventyNavigation:
   order: 6
 description: List of external integrations done by awesome people around the web
 permalink: /third-party-integrations/
-has_toc: true
 ---
 
 # 3rd Party Integrations

--- a/src/docs/third-party-integrations/third-party-integrations.md
+++ b/src/docs/third-party-integrations/third-party-integrations.md
@@ -3,8 +3,8 @@ layout: default
 title: 3rd Party Integrations
 eleventyNavigation:
   key: 3rd Party Integrations
+  order: 6
 description: List of external integrations done by awesome people around the web
-nav_order: 6
 permalink: /third-party-integrations/
 has_toc: true
 ---

--- a/src/docs/third-party-integrations/third-party-integrations.md
+++ b/src/docs/third-party-integrations/third-party-integrations.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: 3rd Party Integrations
+eleventyNavigation:
+  key: 3rd Party Integrations
 description: List of external integrations done by awesome people around the web
-has_children: true
 nav_order: 6
 permalink: /third-party-integrations/
 has_toc: true

--- a/src/index.md
+++ b/src/index.md
@@ -1,6 +1,5 @@
 ---
 layout: index
-nav_exclude: true
 permalink: /
 ---
 

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -4,12 +4,12 @@ eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    {% for page in collections.all %}
-        {% if page.data.external_link == null %}
-        <url>
-            <loc>{{ site.url }}{{ page.url | url }}</loc>
-            <lastmod>{{ page.date.toISOString() }}</lastmod>
-        </url>
-        {% endif %}
+    {%- for page in collections.all %}
+    {%- if page.data.permalink %}
+    <url>
+        <loc>{{ site.url }}{{ page.url | url }}</loc>
+        <lastmod>{{ page.date.toISOString() }}</lastmod>
+    </url>
+    {%- endif -%}
     {% endfor %}
 </urlset>


### PR DESCRIPTION
**Description**

Sooo. This PR escalated quite a bit 😅

- Switched from the hand-made menu generation to the official [navigation plugin](https://www.11ty.dev/docs/plugins/navigation/)
- Cleaned-out the front matter structure to be compatible with the navigation plugin
- Pages can now be excluded from the rendering process and only live in the menus by setting `permalink: false` and `eleventyNavigation.url: https://example.com/` in the front matter
- Introduced canonical link tags
- Added a heading "In this section" for pages with children
- Updated the sitemap to handle the new behavior
- Changed the external link icon 🫢

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
