### PR TITLE
Add trailing slash to local links

### DIFF
--- a/src/docs/getting-started/example.md
+++ b/src/docs/getting-started/example.md
@@ -31,7 +31,7 @@ Both are adjustable in options and are not related to each other (you can animat
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
         labore et dolore magna aliqua.
       </p>
-      <a href="/other-page">Go to other page</a>
+      <a href="/other-page/">Go to other page</a>
     </main>
   </body>
 </html>

--- a/src/index.md
+++ b/src/index.md
@@ -3,13 +3,13 @@ layout: index
 permalink: /
 ---
 
-<a href="/getting-started">
+<a href="/getting-started/">
     <img class="main-logo" src="/assets/images/swup-logo-white.svg" width="400" height="173" alt="{{ site.title }}"/>
 </a>
 
 <h1 class="main-headline">{{ site.description }}</h1>
 
 <p class="main-buttons">
-    <a href="/getting-started" class="btn btn-filled fs-5 mb-4">Docs</a>
+    <a href="/getting-started/" class="btn btn-filled fs-5 mb-4">Docs</a>
     <a href="https://github.com/swup/swup" class="btn fs-5 mb-4">Github</a>
 </p>


### PR DESCRIPTION
Hopefully this fixes the redirect issue on the current front page's "Docs" link