### PR TITLE
Fix edit link to `other-links-config.js`

### DIFF
--- a/src/_includes/sidebar.njk
+++ b/src/_includes/sidebar.njk
@@ -4,7 +4,7 @@
         <div class="links__items" data-links></div>
         <div class="links__buttons">
             <button class="btn-link" data-links-all>Show all</button>
-            <a href="https://github.com/swup/docs/blob/master/assets/js/other-links-config.js" class="btn-link">Add yours</a>
+            <a href="https://github.com/swup/docs/blob/master/src/_assets/js/other-links-config.js" class="btn-link">Add yours</a>
         </div>
     </div>
 </aside>


### PR DESCRIPTION
Fixes the edit link for "Add yours" in the ads section