### PR TITLE
Add example for loading Swup as ESM import from CDN

### DIFF
--- a/src/docs/getting-started/installation.md
+++ b/src/docs/getting-started/installation.md
@@ -13,7 +13,7 @@ permalink: /getting-started/installation/
 
 There are two ways to install the package.
 
-## 1. Bundler
+## Bundler
 
 If you're using a bundler in your project, install swup from npm:
 
@@ -31,9 +31,10 @@ const swup = new Swup({
 });
 ```
 
-## 2. CDN
+## CDN
 
-If you're not using a bundler and want to get started quickly, you can include the minified production file from a CDN:
+If you're not using a bundler and want to get started quickly, you can include
+the minified production file from a CDN:
 
 ```html
 <script src="https://unpkg.com/swup@3"></script>
@@ -43,4 +44,28 @@ In your main script, create a new instance:
 
 ```javascript
 const swup = new Swup();
+```
+
+## ESM
+
+Swup and its plugins can be imported as ES modules for browsers that support it.
+The specifics differ depending on the CDN, but here's a
+[pattern](https://web.dev/serve-modern-code-to-modern-browsers/) for including
+the ES module where supported, and falling back to a UMD version for older
+browsers. Note the `?module` query string in the first import URL.
+
+```html
+<!-- Import Swup as ESM -->
+
+<script type="module">
+  import Swup from "https://unpkg.com/swup@3?module";
+  const swup = new Swup();
+</script>
+
+<!-- Import Swup as UMD for older browsers -->
+
+<script nomodule src="https://unpkg.com/swup@3"></script>
+<script nomodule>
+  const swup = new Swup();
+</script>
 ```


### PR DESCRIPTION
- Add an example for a `module/nomodule` loading pattern
- Use the correct `?module` URL of Unpkg

Closes #84 