### PR TITLE
Make events linkable

### DIFF
--- a/src/_assets/scss/inc/page.scss
+++ b/src/_assets/scss/inc/page.scss
@@ -106,6 +106,10 @@
 			transition: opacity 100ms;
 			opacity: var(--opacity);
 		}
+
+		code {
+			user-select: auto;
+		}
 	}
 }
 
@@ -228,7 +232,6 @@
 	border-radius: 0.2em;
 	user-select: all;
 }
-
 .text a > code {
 	background-image: none;
 	padding-inline: 0;

--- a/src/docs/events/events.md
+++ b/src/docs/events/events.md
@@ -35,29 +35,49 @@ document.addEventListener('swup:contentReplaced', () => {});
 
 ## List of all events
 
-| Event name                 | Description                                                                                                            |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **animationInDone**        | triggers when transition of all animated elements is done (after content is replaced)                                  |
-| **animationInStart**       | triggers when animation _IN_ starts (class `is-animating` is removed from html tag)                                    |
-| **animationOutDone**       | triggers when transition of all animated elements is done (after click of link and before content is replaced)         |
-| **animationOutStart**      | triggers when animation _OUT_ starts (class `is-animating` is added to html tag)                                       |
-| **animationSkipped**       | triggers when transition is skipped (on back/forward buttons)                                                          |
-| **clickLink**              | triggers when link is clicked                                                                                          |
-| **contentReplaced**        | triggers right after the content of page is replaced                                                                   |
-| **disabled**               | triggers on `destroy()`                                                                                                |
-| **enabled**                | triggers when swup instance is created or re-enabled after call of `destroy()`                                         |
-| **hoverLink**              | triggers when link is hovered                                                                                          |
-| **openPageInNewTab**       | triggers when page is opened to new tab (link clicked when control key is pressed)                                     |
-| **pageLoaded**             | triggers when loading of some page is done                                                                             |
-| **pagePreloaded**          | triggers when the preload of some page is done (differs from **pageLoaded** only by the source of event - hover/click) |
-| **pageRetrievedFromCache** | triggers when page is retrieved from cache and no request is necessary                                                 |
-| **pageView**               | similar to **contentReplaced**, except it is once triggered on load                                                    |
-| **popState**               | triggers on popstate events (back/forward button)                                                                      |
-| **samePage**               | triggers when link leading to the same page is clicked                                                                 |
-| **samePageWithHash**       | triggers when link leading to the same page with `#someElement` in the href attribute is clicked                       |
-| **transitionStart**        | triggers when transition start (`loadPage` method is called)                                                           |
-| **transitionEnd**          | triggers when transition ends (content is replaced and all animations are done                                         |
-| **willReplaceContent**     | triggers right before the content of page is replaced                                                                  |
+
+#### `animationInDone`
+triggers when transition of all animated elements is done (after content is replaced)
+#### `animationInStart`
+triggers when animation _IN_ starts (class `is-animating` is removed from html tag)
+#### `animationOutDone`
+triggers when transition of all animated elements is done (after click of link and before content is replaced)
+#### `animationOutStart`
+triggers when animation _OUT_ starts (class `is-animating` is added to html tag)
+#### `animationSkipped`
+triggers when transition is skipped (on back/forward buttons)
+#### `clickLink`
+triggers when link is clicked
+#### `contentReplaced`
+triggers right after the content of page is replaced
+#### `disabled`
+triggers on `destroy()`
+#### `enabled`
+triggers when swup instance is created or re-enabled after call of `destroy()`
+#### `hoverLink`
+triggers when link is hovered
+#### `openPageInNewTab`
+triggers when page is opened to new tab (link clicked when control key is pressed)
+#### `pageLoaded`
+triggers when loading of some page is done
+#### `pagePreloaded`
+triggers when the preload of some page is done (differs from [pageLoaded](#page-loaded) only by the source of event - hover/click)
+#### `pageRetrievedFromCache`
+triggers when page is retrieved from cache and no request is necessary
+#### `pageView`
+similar to [contentReplaced](#content-replaced), except it is once triggered on load
+#### `popState`
+triggers on popstate events (back/forward button)
+#### `samePage`
+triggers when link leading to the same page is clicked
+#### `samePageWithHash`
+triggers when link leading to the same page with `#someElement` in the href attribute is clicked
+#### `transitionStart`
+triggers when transition start (`loadPage` method is called)
+#### `transitionEnd`
+triggers when transition ends (content is replaced and all animations are done
+#### `willReplaceContent`
+triggers right before the content of page is replaced
 
 ## Examples
 


### PR DESCRIPTION
Closes #115 

**Description**

Better to try it out then discussing at length :) 

Converted the table of events to a linkable list. Already nice to be able to link to similar events from the list itself (e.g. "[...]differs from `pageLoaded` [...]") 
