### PR TITLE
Differentiate between transitions and animations

### DIFF
--- a/src/_assets/components/init-swup.js
+++ b/src/_assets/components/init-swup.js
@@ -66,7 +66,7 @@ export default function () {
 
 	window.addEventListener('resize', positionNavIndicators);
 	document.addEventListener('change', (event) => {
-		if (event.target.name === 'theme') changeSwupThemeWithTransition(event.target.value);
+		if (event.target.name === 'theme') changeSwupThemeWithAnimation(event.target.value);
 	});
 	setSwupTheme(new URLSearchParams(window.location.search).get('theme'));
 
@@ -112,11 +112,11 @@ function selectCurrentThemeCheckbox() {
 
 /**
  * Changes the current theme and reloads the page with a related query param.
- * This will show of the new theme's transition immediately
+ * This will show off the new theme's animation immediately
  *
  * @param {string} theme
  */
-function changeSwupThemeWithTransition(theme) {
+function changeSwupThemeWithAnimation(theme) {
 	setSwupTheme(theme);
 
 	const url = new URL(window.location.href);

--- a/src/docs/announcements/swup-4.md
+++ b/src/docs/announcements/swup-4.md
@@ -16,7 +16,7 @@ The swup team is excited to announce swup 4 🎉
 ## What is swup?
 
 [Swup](https://swup.js.org/) is a versatile and extensible **page transition library** for
-server-rendered websites. It manages the complete page load lifecycle and smoothly transitions
+server-rendered websites. It manages the complete page load lifecycle and smoothly animates
 between the current and next page. Make your site feel like a snappy single-page app — without
 any of the complexity.
 
@@ -39,12 +39,12 @@ Please review this [migration guide](/getting-started/upgrading) for details.
 ## Official Astro integration {#astro-integration}
 
 [Astro](https://astro.build/) and swup are a great fit. Where Astro manages the rendering of your
-site, swup takes over on the client side to add page transitions, caching and smart preloading to
-make everything feel smooth and snappy. This has of course always been available for you to set up
-manually.
+site, swup takes over on the client side to add animated page transitions, caching and smart
+preloading to make everything feel smooth and snappy. This has of course always been available for
+you to set up manually.
 
 Now there is an [official Astro integration for swup](https://github.com/swup/astro) for getting
-started quickly. It comes with fade transitions, sane default options, and the most handy plugins
+started quickly. It comes with fade animations, sane default options, and the most handy plugins
 for performance and accessibility out-of-the-box. Astro's bundling and module loading ensures we're
 not hurting performance by only loading swup once the page has finished rendering.
 
@@ -59,7 +59,7 @@ feel free to keep using the [scroll plugin](/plugins/scroll-plugin/).
 
 ### Local animation scope
 
-Swup 4 allows customizing which elements the [transition classes](/getting-started/how-it-works/#transition-classes)
+Swup 4 allows customizing which elements the [animation classes](/getting-started/how-it-works/#animation-classes)
 are added to. The default and recommended way is still adding them globally on the `html` tag.
 However, there is a new [animationScope](/options/#animation-scope) option to add the classes on
 the content containers themselves instead.

--- a/src/docs/api/cache.md
+++ b/src/docs/api/cache.md
@@ -16,7 +16,8 @@ skipping additional server requests, resulting in faster navigation and smoother
 the users.
 
 The cache is enabled automatically and needs no further customization. If your site is highly
-dynamic or doesn't need a cache for other reasons, you can disable it by modifying swup's [cache option](/options/#cache).
+dynamic or doesn't need a cache for other reasons, you can disable it by modifying swup's
+[cache option](/options/#cache).
 
 Swup's cache is available at `swup.cache`. See below for all available methods.
 

--- a/src/docs/api/methods.md
+++ b/src/docs/api/methods.md
@@ -31,7 +31,7 @@ Disable animations for this visit:
 swup.loadPage(url, { animate: false });
 ```
 
-Set a custom transition name:
+Set a custom animation name:
 
 ```javascript
 swup.loadPage(url, { transition: 'custom' });

--- a/src/docs/getting-started/example.md
+++ b/src/docs/getting-started/example.md
@@ -31,12 +31,12 @@ want to wait for this element to finish animating whenever a new page is loaded.
 </main>
 ```
 
-Note: these are just the defaults. Both the container selector and the animation selector are adjustable in the
-[options](/options/).
+Note: these are just the defaults. Both the container selector and the animation selector are
+adjustable in the [options](/options/).
 
-## 2. Transition styles
+## 2. Animation styles
 
-Let's define a CSS transition on the special transition class added before:
+Let's define a CSS transition on the special animation class added before:
 
 ```css
 /* Define a transition duration during page visits */

--- a/src/docs/getting-started/getting-started.md
+++ b/src/docs/getting-started/getting-started.md
@@ -12,9 +12,9 @@ permalink: /getting-started/
 ## What is swup?
 
 Swup is a versatile and extensible **page transition library** for server-rendered websites.
-It manages the complete page load lifecycle and smoothly transitions between the current and next
+It manages the complete page load lifecycle and smoothly animates between the current and next
 page. In addition, it offers many other quality-of-life improvements like **caching**, **smart preloading**,
-native browser history and enhanced **accessibility**.
+native **browser history** and enhanced **accessibility**.
 
 Make your site feel like a snappy single-page app — without any of the complexity.
 
@@ -32,7 +32,7 @@ Make your site feel like a snappy single-page app — without any of the complex
   <li class="feature">
     <span class="feature_icon">✨</span>
     <span class="feature_text">
-      Auto-detects <a href="/getting-started/how-it-works/#timing">CSS transitions</a> for perfect timing
+      Auto-detects <a href="/getting-started/how-it-works/#timing">CSS transitions</a> & animations for perfect timing
     </span>
   </li>
 

--- a/src/docs/getting-started/how-it-works.md
+++ b/src/docs/getting-started/how-it-works.md
@@ -12,7 +12,7 @@ permalink: /getting-started/how-it-works/
 # How it works
 
 Instead of letting the browser load the next page, swup intercepts link clicks, loads the new
-page in the background and smoothly transitions between the old and new content.
+page in the background and smoothly animates between the old and new content.
 
 Read on to learn about key concepts of swup.
 
@@ -23,20 +23,20 @@ Swup will not replace the whole body on each page load. Instead, it will only re
 container with the id `#swup` but you can configure additional containers like headers or navigation
 menus.
 
-## Automatic transition timing {#timing}
+## Automatic animation timing {#timing}
 
-Swup is built around CSS transitions. It will wait for any
+Swup is built around CSS animations. It will wait for any
 [transitions](https://developer.mozilla.org/en-US/docs/Web/CSS/transition) and
 [animations](https://developer.mozilla.org/en-US/docs/Web/CSS/animation) to finish before replacing
-page content. To identify transitions to wait for, swup will look for a special type of class added
+page content. To identify animations to wait for, swup will look for a special type of class added
 to content containers: `transition-[name]`, where `name` is an arbitrary name you can assign
-to allow styling different types of transitions. This [animation selector](/options/#animation-selector)
-can be configured.
+to allow styling different types of animations. This [animation selector](/options/#animation-selector)
+can be freely configured.
 
 It is recommended to only add this class to a **single** element per page. All other elements
-can be transitioned independently to allow easier debugging of transitions.
+can be animated independently to allow easier debugging of animations.
 
-### Transition classes {#classes}
+### Animation classes {#classes}
 
 Swup applies classes to the `html` tag to control the page transition process:
 
@@ -44,15 +44,16 @@ Swup applies classes to the `html` tag to control the page transition process:
 
 | Class name                 | Description                                                                                                            |
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `is-changing` | Added before starting the transition. Removed after the whole transition process. Used for showing the loading state. |
-| `is-animating` | Added before starting the transition. Removed after the content is replaced. Used for defining styles of unloaded pages. |
-| `is-leaving` | Added before starting the transition. Removed right before the content is replaced. Used to identify the **leave** phase of the transition. Combine with `is-animating` to create differing **leave** and **enter** transitions. |
-| `is-rendering` | Added right before the content is replaced. Removed after the whole transition process. Used to identify the **enter** phase of the transition. Combine with `is-animating` to create differing **leave** and **enter** transitions. |
+| `is-changing` | Added before starting the animation. Removed after the whole animation process. Used for showing the loading state. |
+| `is-animating` | Added before starting the animation. Removed after the content is replaced. Used for defining styles of unloaded pages. |
+| `is-leaving` | Added before starting the animation. Removed right before the content is replaced. Used to identify the **leave** phase of the animation. Combine with `is-animating` to create differing **leave** and **enter** animations. |
+| `is-rendering` | Added right before the content is replaced. Removed after the whole animation process. Used to identify the **enter** phase of the animation. Combine with `is-animating` to create differing **leave** and **enter** animations. |
 | `to-[transition]` | Added for links with a `[data-swup-transition]` attribute to change the animation for a specific visit. |
 
 </div>
 
-You can configure swup to [add transition classes to the containers](/options/#animation-scope) instead of the html element.
+You can configure swup to [add animation classes to the containers](/options/#animation-scope)
+instead of the html element.
 
 ## Browser history {#history}
 

--- a/src/docs/getting-started/upgrading.md
+++ b/src/docs/getting-started/upgrading.md
@@ -108,16 +108,16 @@ swup.hooks.before('transitionStart', (context) => {
 });
 ```
 
-The context object replaces the transition object on the swup instance.
+The context object replaces the transition object of swup 3.
 
 ```diff
 - swup.on('transitionStart', () => {
--   console.log('Transition to', swup.transition.to);
--   console.log('Transition name', swup.transition.custom);
+-   console.log('Visit to', swup.transition.to);
+-   console.log('Animation name', swup.transition.custom);
 - });
 + swup.hooks.on('transitionStart', (context) => {
-+   console.log('Transition to', context.to.url);
-+   console.log('Transition name', context.transition.name);
++   console.log('Visit to', context.to.url);
++   console.log('Animation name', context.transition.name);
 + });
 ```
 

--- a/src/docs/lifecycle/context.md
+++ b/src/docs/lifecycle/context.md
@@ -60,8 +60,8 @@ This is an example context object for a visit from `/home` to `/about#footer`.
 What can we do by manipulating the context object? A few examples are listed below.
 
 Note that the most convenient place to hook into is right before `transitionStart` — all the
-information about the current transition is already there, but no requests or animations have yet
-been started.
+information about the current visit is already there, but no requests or animations have started
+yet.
 
 ### Disable animations
 
@@ -73,7 +73,7 @@ swup.hooks.before('transitionStart', (context) => {
 });
 ```
 
-### Custom transition
+### Custom animation
 
 Set a custom `.to-{name}` class on the html element to allow targeting via CSS.
 

--- a/src/docs/lifecycle/hooks.md
+++ b/src/docs/lifecycle/hooks.md
@@ -11,14 +11,13 @@ permalink: /hooks/
 
 # Hooks
 
-Swup provides a variety of hooks that allow listening to lifecycle events,
-customizing the transition process as well as triggering custom logic at specific
-points.
+Swup provides a variety of hooks that allow listening to lifecycle events, customizing the
+transition process as well as triggering custom logic at specific points.
 
 ## Registering handlers
 
-You can register hooks on swup's `hooks` registry. All handlers receive the
-global [context object](/context/) as their first argument.
+You can register hooks on swup's `hooks` registry. All handlers receive the global
+[context object](/context/) as their first argument.
 
 ```javascript
 // Log to the console on each page view
@@ -128,7 +127,7 @@ The following hooks are exposed by swup and can be accessed as such:
 | **openPageInNewTab**       | a link was opened to a new tab                                                                                         |
 | **pageLoaded**             | a page was completely loaded, whether from a request or from cache                                                     |
 | **pageCached**             | a page was saved to the cache                                                                                          |
-| **pageView**               | transition to a new page was completed, also triggers when first enabling swup                                         |
+| **pageView**               | visit to a new page was completed, also triggers when first enabling swup                                         |
 | **popState**               | history navigation was started: back/forward button pressed                                                            |
 | **replaceContent**         | the content of the page is replaced                                                                                    |
 | **samePage**               | a link is clicked that leads to the current page                                                                       |

--- a/src/docs/options/options.md
+++ b/src/docs/options/options.md
@@ -38,10 +38,9 @@ const swup = new Swup({
 
 ## animationSelector
 
-The selector for detecting transition timing. Swup will wait for all CSS transitions and
+The selector for detecting animation timing. Swup will wait for all CSS transitions and
 keyframe animations to finish on these elements before swapping in the content of the new page.
-The default option will select all elements with
-class names beginning in `transition-`.
+The default option will select all elements with class names beginning in `transition-`.
 
 ```javascript
 {
@@ -51,7 +50,7 @@ class names beginning in `transition-`.
 
 ## animationScope
 
-The elements on which swup will add the [transition classes](/getting-started/how-it-works/#transition-classes)
+The elements on which swup will add the [animation classes](/getting-started/how-it-works/#animation-classes)
 for styling the different phases of the in/out animation. By default, it will add those classes
 to the `html` tag. This is great for most use cases and the recommended way to use swup.
 
@@ -199,7 +198,7 @@ and returns a `boolean`.
 
 Swup will skip animations for visits triggered by the back/forward button. If you do require
 animations on history visits, set this to `true`. Swup will add the class `is-popstate` to the html
-tag during those transitions. Defaults to `false`.
+tag during those animations. Defaults to `false`.
 
 ```javascript
 {
@@ -208,5 +207,5 @@ tag during those transitions. Defaults to `false`.
 ```
 
 ⚠️ **Important Note**: This option was added due to popular request. However, it should be used with
-caution. When activated, swup has to disable native [browser scroll restoration](https://developers.google.com/web/updates/2015/09/history-api-scroll-restoration).
-Scroll positions will not be preserved between visits and need to be implemented by you.
+caution. When activated, swup has to disable native [browser scroll restoration](https://developers.google.com/web/updates/2015/09/history-api-scroll-restoration). Scroll positions will not be preserved between visits and need to
+be implemented by you.

--- a/src/docs/other/ci-cd.md
+++ b/src/docs/other/ci-cd.md
@@ -31,7 +31,7 @@ export default {
   },
   //  setup of your validation
   validate: {
-    stylesExpectedToChange: ['opacity', 'transform'], // styles which are animated on your animated elements (checks that at least one is changed during transition)
+    stylesExpectedToChange: ['opacity', 'transform'], // styles which are animated on your animated elements (checks that at least one is changed during animation)
     sitemap: 'public/sitemap.xml', // path or link to your sitemap
     urls: [], // set of URL - if set, swup CLI will check these URLs only (alternative to sitemap)
     baseUrl: '', // baseUrl of your site - if set, swup CLI will crawl the site for you, so you don't need to define URL manually (not referenced pages like 404 won't be checked)

--- a/src/docs/other/common-issues.md
+++ b/src/docs/other/common-issues.md
@@ -23,7 +23,7 @@ If your site does require modular stylesheets per section or template, use the
 [head-plugin](/plugins/head-plugin/) to add the new stylesheets and configure its `awaitAssets`
 option to also wait for those stylesheets to finish loading before animating in the new page.
 
-## The current and next page aren't visible at the same time
+## The current and next page can not be animated at the same time
 
 Out of the box, swup will completely hide the previous page, replace the content and only then
 show the next page. The old and new containers are never in the DOM at the same time.
@@ -83,9 +83,9 @@ index your site.
 
 Some third-party libraries like [Foundation](https://foundation.zurb.com/) might already be using
 class names like `transition-*` for their own functionality. In this case, swup will try to wait
-for transitions on those elements, quite possibly messing up the timing of transitions.
+for animations on those elements, quite possibly messing up the timing of animations.
 
-Using a stricter [animationSelector](/options/#animation-selector) fixes the issue.
+Using a stricter [animation selector](/options/#animation-selector) fixes the issue.
 
 ```javascript
 var swup = new Swup({
@@ -109,14 +109,14 @@ html.is-animating .swup-transition-fade {
 
 ## Overused `transition-*` classes
 
-Swup will wait for any element with a `transition-*` class to finish transitioning.
+Swup will wait for any element with a `transition-*` class to finish animating.
 While there is an unlimited number of elements that can have this class, only one is actually
 required for swup to get its timing right. Using it on all animated elements is not required and
 often leads to bugs.
 
-It is recommended to use one element with a `transition-*` class to set the page
-transition duration and make any other transition happen independently. As long as all transitions
-share the same duration, the should be no issues with this approach.
+It is recommended to use one element with a `transition-*` class to set the animation duration and
+make any other animations happen independently. As long as all animations share the same duration,
+there should be no issues with this approach.
 
 ```css
 /* Note: no transition-* prefix */

--- a/src/docs/plugins/js-plugin.md
+++ b/src/docs/plugins/js-plugin.md
@@ -5,7 +5,7 @@ eleventyNavigation:
   key: JS Plugin
   parent: Plugins
   order: 12
-description: A swup plugin for managing transitions in JS
+description: A swup plugin for managing animations in JS
 permalink: /plugins/js-plugin/
 repo_link: https://github.com/swup/js-plugin
 ---

--- a/src/docs/plugins/livewire-plugin.md
+++ b/src/docs/plugins/livewire-plugin.md
@@ -5,7 +5,7 @@ eleventyNavigation:
   key: Laravel Livewire Plugin
   parent: Plugins
   order: 13
-description: Plguin to refresh Livewire components after swup page transition
+description: A swup plugin for integrating Laravel Livewire
 permalink: /plugins/livewire-plugin/
 repo_link: https://github.com/swup/livewire-plugin
 ---

--- a/src/docs/themes/fade-theme.md
+++ b/src/docs/themes/fade-theme.md
@@ -5,7 +5,7 @@ eleventyNavigation:
   key: Fade Theme
   parent: Themes
   order: 1
-description: Theme to fade pages on the transition
+description: A swup theme for fade animations
 permalink: /themes/fade-theme/
 repo_link: https://github.com/swup/fade-theme
 ---

--- a/src/docs/themes/overlay-theme.md
+++ b/src/docs/themes/overlay-theme.md
@@ -5,7 +5,7 @@ eleventyNavigation:
   key: Overlay Theme
   parent: Themes
   order: 3
-description: Theme to hide pages behind overlay on the transition
+description: A swup theme for showing an overlay during animations
 permalink: /themes/overlay-theme/
 repo_link: https://github.com/swup/overlay-theme
 ---

--- a/src/docs/themes/slide-theme.md
+++ b/src/docs/themes/slide-theme.md
@@ -5,7 +5,7 @@ eleventyNavigation:
   key: Slide Theme
   parent: Themes
   order: 2
-description: Theme to slide and fade pages on the transition
+description: A swup theme for slide and fade animations
 permalink: /themes/slide-theme/
 repo_link: https://github.com/swup/slide-theme
 ---


### PR DESCRIPTION
**Description**

- Use `transition` for the whole process of going from one page to the next
- Use `animation` for visually animated transitions with a duration
- Preparation for switching these terms in the actual code
