### PR TITLE
Make Common Issues more prominent

### DIFF
--- a/src/docs/getting-started/common-issues.md
+++ b/src/docs/getting-started/common-issues.md
@@ -3,27 +3,36 @@ layout: default
 title: Common Issues
 eleventyNavigation:
   key: Common Issues
-  parent: Other
-  order: 2
+  parent: Getting Started
+  order: 8
 description: Description of common issue or caveats people encounter
-permalink: /other/common-issues/
+permalink: /getting-started/common-issues/
 ---
 
 # Common Issues
 
-This is a compilation of challenges and possible solutions when integrating or extending swup.
+This is a compilation of challenges and suggested solutions when integrating or extending swup.
 
-## The stylesheets of the next page are not loaded
+## Scripts on the next page are not executed
+
+Swup doesn't insert new script tags by default. To run code after a page visit, you have a few
+options that are explained in the section on [Reloading Scripts](/getting-started/reloading-javascript/).
+
+- [Trigger custom code](/getting-started/reloading-javascript/#triggering-custom-code) using hooks
+- Use the [Head Plugin](/plugins/head-plugin/) to load new script files into the current head element
+- Use the [Scripts Plugin](/plugins/scripts-plugin/) to re-evaluate new scripts in either head or body
+
+## Stylesheets of the next page are not loaded
 
 Swup doesn't automatically update the contents of the `head` tag. Any stylesheets not included in
 the current page's `head` will not be loaded. The easiest solution is to use a single stylesheet
 for the whole website.
 
 If your site does require modular stylesheets per section or template, use the
-[head-plugin](/plugins/head-plugin/) to add the new stylesheets and configure its `awaitAssets`
+[Head Plugin](/plugins/head-plugin/) to add the new stylesheets and configure its `awaitAssets`
 option to also wait for those stylesheets to finish loading before animating in the new page.
 
-## The current and next page can not be animated at the same time
+## Current and next page are not visible at the same time
 
 Out of the box, swup will completely hide the previous page, replace the content and only then
 show the next page. The old and new containers are never in the DOM at the same time.

--- a/src/docs/getting-started/getting-started.md
+++ b/src/docs/getting-started/getting-started.md
@@ -108,7 +108,7 @@ Get started quickly with one of three official themes: [fade](/themes/fade-theme
 
 ## Having trouble?
 
-If you're having trouble implementing swup, check out [Common Issues](/other/common-issues/), look
+If you're having trouble implementing swup, check out [Common Issues](/getting-started/common-issues/), look
 at [closed issues](https://github.com/swup/swup/issues?q=is%3Aissue+is%3Aclosed), or create a
 [new discussion](https://github.com/swup/swup/discussions/new).
 

--- a/src/docs/getting-started/reloading-javascript.md
+++ b/src/docs/getting-started/reloading-javascript.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: Reloading Scripts
-eleventyNavigation:
-  key: Reloading Scripts
-  parent: Getting Started
-  order: 8
+eleventyNavigation: false
 description: How to trigger custom code when a new page is loaded.
 permalink: /getting-started/reloading-javascript/
 ---


### PR DESCRIPTION
- Move [Common Issues](https://deploy-preview-119--splendorous-kataifi-9ae281.netlify.app/other/common-issues/) to the _Getting Started_ section
- Add text about reloading scripts as the first common issue, and link to subpage
- Remove Reloading Scripts from _Getting Started_ Section
- Goal: provide a useful entrypoint for all types of issues, including but not limited to scripts

<img width="1091" alt="Screenshot 2023-07-19 at 14 58 26" src="https://github.com/swup/docs/assets/22225348/0cf890fd-7772-474e-9b5e-01d76ddf594a">
