### PR TITLE
GitHub Videos

### DIFF
--- a/src/_assets/components/alpine/VersionSelect/VersionSelect.js
+++ b/src/_assets/components/alpine/VersionSelect/VersionSelect.js
@@ -4,7 +4,6 @@ export default () => {
 	return {
 
 		init() {
-			console.log(this.$refs.options.content);
 			tippy(this.$refs.button, {
 				content: this.$refs.options.content,
 				allowHTML: true,

--- a/src/_assets/components/alpine/Video/Video.js
+++ b/src/_assets/components/alpine/Video/Video.js
@@ -1,0 +1,10 @@
+export default () => {
+	return {
+		init() {
+			const src = this.$root.textContent.trim();
+			if (!src) return;
+			const video = `<video muted playsinline loop autoplay controls src="${src}"></video>`;
+			this.$root.innerHTML = video;
+		},
+	}
+};

--- a/src/_assets/components/init-alpine.js
+++ b/src/_assets/components/init-alpine.js
@@ -13,6 +13,7 @@ import MobileNav from './alpine/MobileNav/MobileNav.js';
 import SearchUI from './alpine/SearchUI/SearchUI.js';
 import TableOfContents from './alpine/TableOfContents/TableOfContents.js';
 import VersionSelect from './alpine/VersionSelect/VersionSelect.js';
+import Video from './alpine/Video/Video.js';
 
 
 export default function () {
@@ -26,5 +27,6 @@ export default function () {
 	Alpine.data('MobileNav', MobileNav);
 	Alpine.data('TableOfContents', TableOfContents);
 	Alpine.data('VersionSelect', VersionSelect);
+	Alpine.data('Video', Video);
 	Alpine.start();
 }


### PR DESCRIPTION
**Description**

Auto-embeds videos from github readmes if they are wrapped like this:

```html
<div x-data="Video">
  
https://user-images.githubusercontent.com/869813/256012207-1d12f061-2a9c-443b-9bf0-e37a7e559852.mp4

</div>
```

Drive-By optimizations:
- Removed logging from `VersionSelect` component
- Formatted code

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
