### PR TITLE
Update docs on recent features

### DIFF
--- a/src/docs/api/markup.md
+++ b/src/docs/api/markup.md
@@ -53,18 +53,18 @@ html.is-changing.to-slide .transition-page {
 
 ## Persist element state
 
-Some elements need to keep their state between page loads, e.g. autoplay videos, animations,
-countdowns, etc. Swup will move an element over to the next page — with all its content, events
-and state — if it has a `data-swup-persist` attribute and a matching element is found on the
+Some elements need to keep their state between page loads, e.g. autoplay videos, animations or
+countdowns. Swup will transfer an element to the next page — preserving its content, data and
+event listeners — if it has a `data-swup-persist` attribute and a matching element is found on the
 next page. Elements are matched using the unique value of the persist attribute.
 
 ```html
 <video src="/video.mp4" autoplay data-swup-persist="unique-key">
 ```
 
-While in many cases it is enough to have persistent elements outside of any
+While this can also be achieved by having persistent elements outside of any
 [containers](/options/#containers) replaced by swup, this attribute is meant for
-elements inside replaced containers.
+elements inside replaced containers that cannot be moved outside.
 
 ## Replace history entry
 

--- a/src/docs/api/markup.md
+++ b/src/docs/api/markup.md
@@ -1,0 +1,76 @@
+---
+layout: default
+title: Markup
+eleventyNavigation:
+  key: Markup
+  parent: API
+  order: 6
+description: Influence swup behavior with DOM attributes
+permalink: /api/markup/
+---
+
+# Markup
+
+Control swup's behavior using specific DOM attributes on links and other elements.
+
+## Ignore links
+
+Swup can be disabled on a per-link basis by annotating a link or any of its
+ancestors with `data-no-swup`:
+
+```html
+<a href="/" data-no-swup>Ignored</a>
+
+<nav data-no-swup>
+  <a href="/">Ignored</a>
+</nav>
+```
+
+## Set custom animation
+
+Adding a `data-swup-animation` attribute on a link will change the animation for a
+specific visit.
+
+```html
+<a href="/" data-swup-animation="slide">
+```
+
+Technically, this will add a `.to-{animation}` class on the HTML element you can
+use to specify custom transition styles:
+
+```html
+<html class="is-changing is-animating to-slide">
+```
+
+```css
+html.is-changing .transition-page {
+  /* normal transition styles */
+}
+html.is-changing.to-slide .transition-page {
+  /* slide transition styles */
+}
+```
+
+## Persist element state
+
+Some elements need to keep their state between page loads, e.g. autoplay videos, animations,
+countdowns, etc. Swup will move an element over to the next page — with all its content, events
+and state — if it has a `data-swup-persist` attribute and a matching element is found on the
+next page. Elements are matched using the unique value of the persist attribute.
+
+```html
+<video src="/video.mp4" autoplay data-swup-persist="unique-key">
+```
+
+While in many cases it is enough to have persistent elements outside of any
+[containers](/options/#containers) replaced by swup, this attribute is meant for
+elements inside replaced containers.
+
+## Replace history entry
+
+Swup will replace the current history entry (instead of creating a new one) by
+adding a `data-swup-history` attribute with the value `replace` to a link:
+
+```html
+<a href="/" data-swup-history="replace">
+```

--- a/src/docs/api/markup.md
+++ b/src/docs/api/markup.md
@@ -26,7 +26,7 @@ ancestors with `data-no-swup`:
 </nav>
 ```
 
-## Set custom animation
+## Set a custom animation
 
 Adding a `data-swup-animation` attribute on a link will change the animation for a
 specific visit.
@@ -35,7 +35,7 @@ specific visit.
 <a href="/" data-swup-animation="slide">
 ```
 
-Technically, this will add a `.to-{animation}` class on the HTML element you can
+This will add a `.to-{animation}` class on the HTML element during the visit you can
 use to specify custom transition styles:
 
 ```html
@@ -53,7 +53,7 @@ html.is-changing.to-slide .transition-page {
 
 ## Persist element state
 
-Some elements need to keep their state between page loads, e.g. autoplay videos, animations or
+Some elements need to keep their state between page loads, e.g. autoplaying videos, animations or
 countdowns. Swup will transfer an element to the next page — preserving its content, data and
 event listeners — if it has a `data-swup-persist` attribute and a matching element is found on the
 next page. Elements are matched using the unique value of the persist attribute.

--- a/src/docs/api/methods.md
+++ b/src/docs/api/methods.md
@@ -43,6 +43,12 @@ Send a POST request with form data:
 swup.navigate(url, { method: 'POST', data: new FormData() });
 ```
 
+Disable the cache for this request:
+
+```javascript
+swup.navigate(url, { cache: { read: false, write: true } });
+```
+
 ## destroy
 
 Disables swup.

--- a/src/docs/lifecycle/visit.md
+++ b/src/docs/lifecycle/visit.md
@@ -29,12 +29,17 @@ swup.hooks.on('page:view', (visit) => {
 
 ## Shape of the visit object
 
-This is an example visit object for a navigation from `/home` to `/about#footer`.
+This is an example visit object for a navigation from `/home` to `/about#anchor`.
 
 ```javascript
 {
-  from: { url: '/home' },
-  to: { url: '/about' },
+  from: {
+    url: '/home'
+  },
+  to: {
+    url: '/about',
+    hash: '#anchor'
+  },
   containers: ['#swup'],
   animation: {
     animate: true,
@@ -44,6 +49,10 @@ This is an example visit object for a navigation from `/home` to `/about#footer`
     el: /* <a> element */,
     event: /* MouseEvent */
   },
+  cache: {
+    read: true,
+    write: true
+  },
   history: {
     action: 'push',
     popstate: false,
@@ -51,7 +60,7 @@ This is an example visit object for a navigation from `/home` to `/about#footer`
   },
   scroll: {
     reset: true,
-    target: '#footer'
+    target: '#anchor'
   }
 }
 ```
@@ -136,5 +145,26 @@ swup.hooks.on('visit:start', (visit) => {
   if (visit.history.popstate) {
     console.log('History visit', visit.history.direction);
   }
+});
+```
+
+### Replace history entry
+
+Tell swup to replace the current history entry, instead of creating a new one.
+
+```javascript
+swup.hooks.on('visit:start', (visit) => {
+  visit.history.action = 'replace';
+});
+```
+
+### Disable cache
+
+Control whether swup will check for existing pages in the cache or save the newly loaded page
+to the cache. Overwrites the behavior set in the [cache option](/options/#cache).
+
+```javascript
+swup.hooks.on('visit:start', (visit) => {
+  visit.cache.read = false;
 });
 ```


### PR DESCRIPTION
**Description**

- Document `cache` option in `swup.navigate()`
- Document `cache` key in visit object
- Document `to.hash` key in visit object
- Add example hook handlers for manipulating the above 
- Create `API → Markup` page to document all DOM attributes for controlling swup behavior
  - Ignoring links
  - Setting custom animations
  - Persisting element state
  - Replacing history entries

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)