### PR TITLE
Update faulty link in plugins.md

### DIFF
--- a/src/docs/plugins/plugins.md
+++ b/src/docs/plugins/plugins.md
@@ -20,7 +20,7 @@ These are plugins developed and maintained by the swup core team.
 
 |                        Plugin                         |                    Features                    |
 | ----------------------------------------------------- | ---------------------------------------------- |
-| [Accessibility Plugin](/plugins/accessibility-plugin) | Enhance accessibility                          |
+| [Accessibility Plugin](/plugins/a11y-plugin) | Enhance accessibility                          |
 | [Body Class Plugin](/plugins/body-class-plugin)       | Update the body classname                      |
 | [Debug Plugin](/plugins/debug-plugin)                 | Debug and get help in development              |
 | [Forms Plugin](/plugins/forms-plugin)                 | Submit forms with animations                   |


### PR DESCRIPTION
https://swup.js.org/plugins/accessibility-plugin does not exist. It is supposed to be https://swup.js.org/plugins/a11y-plugin

<!--
Thanks for creating this pull request!

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple PRs instead of opening a huge one.
-->

**Description**

<!--
Clear and concise description of the proposed changes, as well as a convincing reason for adding them to swup.
-->

There is an incorrect link in the plugins.md file, which has `/plugins/accessibility-plugin` and is supposed to be `/plugins/a11y-plugin`, so I just thought I would fix it.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [x] The documentation was updated as required

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
