### PR TITLE
Update pagefind to `1.0.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "markdown-it-video": "^0.6.3",
         "mini-css-extract-plugin": "^2.5.3",
         "minimist": "^1.2.5",
-        "pagefind": "^0.12.0",
+        "pagefind": "^1.0.2",
         "postcss": "^8.4.6",
         "postcss-loader": "^6.2.1",
         "postcss-preset-env": "^7.8.3",
@@ -3237,6 +3237,71 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-saHinnIbchShIeT7+fFe77k3cbtXxbLcK4m+MjZA8VM/lrLeTaS+UYUYCzpKmV4U+APeELnquL4fhDquFAcScQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-CAyPARt41lHPpHD8O7O2zv8MJa06iPa6nrGt+o9puY47OcNM6x8GxCAKPR1OTfEsiuwPovAdi7rvwJ35z3tnrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.0.2.tgz",
+      "integrity": "sha512-bGpLKV2WLkLH/Qn/ibHJj7oTPvMcpJMwcjdPWk+tWqBl5xoBK1l4k45Gi70deCdIjKom5TcXuS8mgcXY8tSJ0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.0.2.tgz",
+      "integrity": "sha512-59beym/0riPCTjNeT91ksqlBToW0FFeFAHKxvM0nmvzEeNYurgoZY+8fJz9Xvz8icXhi2NxLirDgclAMsahWWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.0.2.tgz",
+      "integrity": "sha512-lwae3p7xOVihaTv6D8gJJLl05U4lDvkyMN9azlpjlWbfhBJXJnvD2CQTDwzZxK+u6ZDJUR1Qcz2oVeedyQpMjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@pkgr/utils": {
       "version": "2.4.2",
@@ -9775,17 +9840,19 @@
       }
     },
     "node_modules/pagefind": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-0.12.0.tgz",
-      "integrity": "sha512-LHUmlYYweBM6/rK1G+7z2q2WjYeycrB7g5Kuw0w6yMkYztzsEdO2Qj2pJ3z8gsWV8eJsYQyAGOAdqE3SZWlCqA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.0.2.tgz",
+      "integrity": "sha512-UxZgvmknPrH25qXZL7aK5fUOj1GrZxEQb2Mdd4l2m/PtdKJfrszxOR2EI1349bCYZ+OxiPn7wz2NCRNzb3QPpA==",
       "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "proxy-from-env": "^1.1.0"
-      },
       "bin": {
-        "pagefind": "lib/index.js"
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.0.2",
+        "@pagefind/darwin-x64": "1.0.2",
+        "@pagefind/linux-arm64": "1.0.2",
+        "@pagefind/linux-x64": "1.0.2",
+        "@pagefind/windows-x64": "1.0.2"
       }
     },
     "node_modules/parent-module": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "markdown-it-video": "^0.6.3",
     "mini-css-extract-plugin": "^2.5.3",
     "minimist": "^1.2.5",
-    "pagefind": "^0.12.0",
+    "pagefind": "^1.0.2",
     "postcss": "^8.4.6",
     "postcss-loader": "^6.2.1",
     "postcss-preset-env": "^7.8.3",

--- a/src/_assets/components/alpine/SearchUI/SearchUI.js
+++ b/src/_assets/components/alpine/SearchUI/SearchUI.js
@@ -20,7 +20,7 @@ export default () => {
 				return;
 			}
 			this.isSearching = true;
-			const pagefind = await import(/* webpackIgnore: true */ '/_pagefind/pagefind.js');
+			const pagefind = await import(/* webpackIgnore: true */ '/pagefind/pagefind.js');
 			const search = await pagefind.search(term);
 			const results = await Promise.all(
 				search.results.slice(0, postsPerPage).map((r) => r.data())


### PR DESCRIPTION
**Description**

Pagefind 1 [is out](https://github.com/CloudCannon/pagefind/releases/tag/v1.0.0)! Time to use it 🎉

Major improvement with weighing, try searching for "plugin" in the deploy preview vs the current swup.js.org

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
