### PR TITLE
Prettier: ignore markdown files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Currently there is no way to tell prettier to ignore code blocks in markdown files.
+# The next best thing is to ignore .md files alltogether:
+**/*.md

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:assets": "webpack --mode=production  --progress --stats minimal",
     "build": "npm run build:eleventy && npm run build:assets",
     "clean": "rm -rf _site",
+    "lint": "prettier 'src/' --check",
     "format": "prettier 'src/' --write",
     "test": "start-server-and-test test:start http://127.0.0.1:7987 test:run",
     "test:serve": "http-server --port 7987 --silent _site",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:assets": "webpack --mode=production  --progress --stats minimal",
     "build": "npm run build:eleventy && npm run build:assets",
     "clean": "rm -rf _site",
-    "lint": "prettier 'src/' --write",
+    "format": "prettier 'src/' --write",
     "test": "start-server-and-test test:start http://127.0.0.1:7987 test:run",
     "test:serve": "http-server --port 7987 --silent _site",
     "test:start": "SITE_URL=http://127.0.0.1:7987 npm run build && npm run test:serve",

--- a/src/_assets/components/alpine/Intro/Intro.js
+++ b/src/_assets/components/alpine/Intro/Intro.js
@@ -53,7 +53,6 @@ export default () => {
 			tl.from(this.$refs.dot1, { ...popIn, y: -20 }, '<0.3');
 			tl.from(this.$refs.dot2, { ...popIn, y: -20 }, letterDelay);
 
-
 			tl.from(this.$refs.slogan, fadeIn, '<0.3');
 
 			tl.from(this.$refs.button1, fadeIn, letterDelay);

--- a/src/_assets/components/alpine/VersionSelect/VersionSelect.js
+++ b/src/_assets/components/alpine/VersionSelect/VersionSelect.js
@@ -1,16 +1,15 @@
-import tippy from "tippy.js";
+import tippy from 'tippy.js';
 
 export default () => {
 	return {
-
 		init() {
 			tippy(this.$refs.button, {
 				content: this.$refs.options.content,
 				allowHTML: true,
 				interactive: true,
-				trigger: 'click',
+				trigger: 'click'
 				// theme: 'light',
-			})
-		},
-	}
+			});
+		}
+	};
 };

--- a/src/_assets/components/init-alpine.js
+++ b/src/_assets/components/init-alpine.js
@@ -14,7 +14,6 @@ import SearchUI from './alpine/SearchUI/SearchUI.js';
 import TableOfContents from './alpine/TableOfContents/TableOfContents.js';
 import VersionSelect from './alpine/VersionSelect/VersionSelect.js';
 
-
 export default function () {
 	window.Alpine = Alpine;
 	Alpine.data('Intro', Intro);

--- a/src/_assets/scss/inc/page.scss
+++ b/src/_assets/scss/inc/page.scss
@@ -126,7 +126,7 @@
 	}
 	.screencast_header_dots:before,
 	.screencast_header_dots:after {
-		content: "";
+		content: '';
 		position: absolute;
 		top: 0;
 	}
@@ -294,7 +294,7 @@
 
 .shiki {
 	--shiki-padding-block: 0.5rem;
-	--shiki-padding-inline: .8rem;
+	--shiki-padding-inline: 0.8rem;
 	width: 100%;
 	overflow: auto;
 	padding-block: var(--shiki-padding-block);
@@ -314,7 +314,7 @@
 	&:before {
 		content: ' ';
 		display: inline-block;
-		transform: translateX(calc(-1 * var(--shiki-padding-inline) + .5em));
+		transform: translateX(calc(-1 * var(--shiki-padding-inline) + 0.5em));
 	}
 }
 
@@ -385,7 +385,7 @@
 
 html.dark .shiki-container .github-light,
 html:not(.dark) .shiki-container .github-dark {
-  display: none;
+	display: none;
 }
 
 /*

--- a/src/_assets/scss/inc/props.scss
+++ b/src/_assets/scss/inc/props.scss
@@ -51,13 +51,12 @@
 		0 4px 12px -5px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 5%)),
 		0 12px 15px -5px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 7%));
 
-	--shadow-4:
-    0 -2px 5px 0 hsl(var(--shadow-color) / calc(var(--shadow-strength) + 2%)),
-    0 1px 1px -2px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 3%)),
-    0 2px 2px -2px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 3%)),
-    0 5px 5px -2px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 4%)),
-    0 9px 9px -2px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 5%)),
-    0 16px 16px -2px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 6%));
+	--shadow-4: 0 -2px 5px 0 hsl(var(--shadow-color) / calc(var(--shadow-strength) + 2%)),
+		0 1px 1px -2px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 3%)),
+		0 2px 2px -2px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 3%)),
+		0 5px 5px -2px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 4%)),
+		0 9px 9px -2px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 5%)),
+		0 16px 16px -2px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 6%));
 
 	--external-link-icon-light: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' %3E%3Cline x1='7' y1='17' x2='17' y2='7'%3E%3C/line%3E%3Cpolyline points='7 7 17 7 17 17'%3E%3C/polyline%3E%3C/svg%3E");
 	--external-link-icon-dark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' %3E%3Cline x1='7' y1='17' x2='17' y2='7'%3E%3C/line%3E%3Cpolyline points='7 7 17 7 17 17'%3E%3C/polyline%3E%3C/svg%3E");

--- a/src/_assets/scss/inc/version-select.scss
+++ b/src/_assets/scss/inc/version-select.scss
@@ -1,4 +1,3 @@
-
 .version-select_label {
 	font-size: 0.95rem;
 	display: flex;

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -14,8 +14,8 @@ module.exports = function () {
 			},
 			{
 				label: 'swup v3',
-				url: 'https://v3.swup.js.org',
-			},
+				url: 'https://v3.swup.js.org'
+			}
 		]
 	};
 };


### PR DESCRIPTION
Fixes #155 

**Description**

Seems like it's not possible to elegantly tell prettier to ignore code blocks in markdown files. Next best thing: ignore `.md` files alltogether, so that we can at least keep our business code formatting consistent.

Drive-By:

- Changed `lint` script to only check the formatting
- Introduced `format` script that will write the formatting
- Formatted .js and .scss files

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)