### PR TITLE
Automatically focus the search input on mobile

### DIFF
--- a/src/_assets/components/alpine/SearchUI/SearchUI.js
+++ b/src/_assets/components/alpine/SearchUI/SearchUI.js
@@ -7,6 +7,11 @@ export default () => {
 		isSearching: false,
 		init() {
 			this.$watch('term', this.search.bind(this));
+			Alpine.effect(async () => {
+				if (!this.isOpen) return;
+				await this.$nextTick();
+				this.$refs.input.focus();
+			})
 		},
 		reset() {
 			this.results = [];

--- a/src/_assets/components/alpine/SearchUI/SearchUI.js
+++ b/src/_assets/components/alpine/SearchUI/SearchUI.js
@@ -11,7 +11,7 @@ export default () => {
 				if (!this.isOpen) return;
 				await this.$nextTick();
 				this.$refs.input.focus();
-			})
+			});
 		},
 		reset() {
 			this.results = [];

--- a/src/_includes/search.njk
+++ b/src/_includes/search.njk
@@ -57,7 +57,7 @@
                 >
                   <form class="search_ui_form" x-on:click.stop>
                     {% feather "search" %}
-                    <input class="search_ui_input" type="text" x-model="term"></input>
+                    <input x-ref="input" class="search_ui_input" type="text" x-model="term"></input>
                   </form>
 
                   <template x-if="term.length > 1 && !isSearching && !results.length">


### PR DESCRIPTION
**Description**

Fixes the searchinput not being autofocussed on mobile (iOS)

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
