### PR TITLE
Fetch and display plugin versions from repo

### DIFF
--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -122,6 +122,7 @@ function sortByOrder(pages) {
  * @returns {string}
  */
 async function prepareContent(content) {
+	await maybeLoadPackageInfo(this.ctx);
 	content = await maybeLoadRemoteReadme(content, this.ctx);
 
 	content = modifyMainTitle(content, this.ctx);
@@ -150,34 +151,58 @@ async function maybeLoadRemoteReadme(content, ctx) {
 
 	if (!repo_link) return content;
 
-	const repoBase = repo_link.replace('github.com', 'raw.githubusercontent.com');
-	const repoURL = `${repoBase}/master/README.md`;
-
-	if (repoReadmes.has(repoURL)) {
-		return repoReadmes.get(repoURL);
+	if (repoReadmes.has(repo_link)) {
+		return repoReadmes.get(repo_link);
 	}
 
-	let result;
-	try {
-		result = await EleventyFetch(repoURL, { duration: '60s', type: 'text' });
-	} catch (error) {
-		try {
-			result = await EleventyFetch(repoURL.toLowerCase(), { duration: '60s', type: 'text' });
-		} catch (error) {
-			console.error(`Could not load remote readme for ${repoURL}`);
-		}
-	}
+	let result = await loadGitHubRepoFile(repo_link, 'README.md', 'text');
 
 	// Honor <!-- swup-docs-ignore-start -->Ignore me!<!-- swup-docs-ignore-end -->
-	result = result.replace(
+	result = (result || '').replace(
 		/<!--(?:\s+)swup-docs-ignore-start(?:\s+)-->.+?<!--(?:\s+)swup-docs-ignore-end(?:\s+)-->/gis,
 		''
 	);
 
 	const readmeHTML = customMarkdownIt.render(result);
-	repoReadmes.set(repoURL, readmeHTML);
+	repoReadmes.set(repo_link, readmeHTML);
 
 	return readmeHTML;
+}
+
+/**
+ * Load package info if repo_link is defined
+ *
+ * @param {object} ctx The current context
+ */
+async function maybeLoadPackageInfo(ctx) {
+	let { repo_link } = ctx;
+	if (!repo_link) return;
+
+	const result = await loadGitHubRepoFile(repo_link, 'package.json', 'json');
+
+	ctx.package_info = result || {};
+}
+
+/**
+ * Load a raw file from a GitHub repo
+ * @param {string} repoLink
+ * @param {string} filePath
+ * @param {string} type
+ */
+async function loadGitHubRepoFile(repoLink, filePath, type = 'text') {
+	const repoBase = repoLink.replace('github.com', 'raw.githubusercontent.com');
+	const repoURL = `${repoBase}/master/${filePath}`;
+
+	try {
+		return await EleventyFetch(repoURL, { duration: '60s', type });
+	} catch (error) {
+		try {
+			return await EleventyFetch(repoURL.toLowerCase(), { duration: '60s', type });
+		} catch (error) {
+			console.error(`Erro loading ${filePath} from ${repoURL}: ${error.message}`);
+			return null;
+		}
+	}
 }
 
 /**
@@ -188,20 +213,30 @@ async function maybeLoadRemoteReadme(content, ctx) {
  * @returns {string}
  */
 function modifyMainTitle(content, ctx) {
-	const { repo_link, title } = ctx;
+	const { title, repo_link, package_info } = ctx;
 
-	const repoLinkHTML = !repo_link
-		? ''
-		: /* html */ `
-		<div class="buttons page_body_header_buttons">
+	const repoLinkHTML = repo_link
+		? `
 			<a class="button is-external" target="_blank" href="${repo_link}">
 				<span class="button_label">Repo</span>
 				<svg role="img" viewBox="0 0 24 24" width="24" height="24" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><title>GitHub</title><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
 			</a>
-		</div>
-	`.trim();
+		`
+		: '';
 
-	const headerHTML = /* html */ `<div class="page_body_header">${repoLinkHTML}<h1>${title}</h1></div>`;
+	const changelogLinkHTML = package_info?.version
+		? `
+			<a class="button is-external" target="_blank" href="${repo_link}/blob/master/CHANGELOG.md">
+				<span class="button_label">v${package_info.version}</span>
+			</a>
+		`
+		: '';
+
+	const headerLinkHTML = repoLinkHTML || changelogLinkHTML
+		? `<div class="buttons page_body_header_buttons">${changelogLinkHTML.trim()} ${repoLinkHTML.trim()}</div>`
+		: '';
+
+	const headerHTML = /* html */ `<div class="page_body_header">${headerLinkHTML}<h1>${title}</h1></div>`;
 	return content.trim().replace(/^<h1.*?>(.+?)<\/h1>/, headerHTML);
 }
 


### PR DESCRIPTION
**Description**

- Fetch current package version from the repo's `package.json`
- Display the package version next to the repo button, and link directly to repo's CHANGELOG.md
- Abstract repo file fetching into new function `loadGitHubRepoFile`
- This should work since all merges to master in plugin repos trigger a docs rebuild

**Screenshot**

<img width="600" alt="Screenshot 2023-10-09 at 15 03 06" src="https://github.com/swup/docs/assets/22225348/cc991e64-e3ab-4677-bad8-492915ffd5f3">

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
