### PR TITLE
Convert camelcase anchor links to lowercase one-word instead of kebab-case

### DIFF
--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -30,7 +30,7 @@ const customMarkdownIt = markdownIt({
 customMarkdownIt.use(markdownItAnchor, {
 	permalink: markdownItAnchor.permalink.headerLink({ safariReaderFix: true }),
 	level: 2,
-	slugify: (s) => slugify(s)
+	slugify: (s) => slugify(s.toLowerCase())
 });
 
 /**


### PR DESCRIPTION
Replaces https://github.com/swup/preload-plugin/pull/115

**Description**

Make anchor links behave more like on GitHub. For example, with `preloadVisibleLinks` as input:

- before: `preload-visible-links`
- after: `preloadvisiblelinks` 

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
