### PR TITLE
Fix readme links for remote repos

### DIFF
--- a/src/_includes/page.njk
+++ b/src/_includes/page.njk
@@ -21,7 +21,7 @@
       <p>
         {% feather "edit" %}
         {% if repo_link %}
-          <a href="{{ repo_link }}/blob/master/readme.md" target="_blank">Suggest changes to this page</a>
+          <a href="{{ repo_link }}/blob/master/README.md" target="_blank">Suggest changes to this page</a>
         {% else %}
           <a href="https://github.com/swup/docs/blob/master/src{{ page.filePathStem }}.md" target="_blank">Suggest changes to this page</a>
         {% endif %}


### PR DESCRIPTION
Fixes https://github.com/swup/swup/issues/813

**Description**

Fix the link "Suggest changes to this page" for remote repos (uppercase README.md)

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
