### PR TITLE
Fix background color for infoblocks

### DIFF
--- a/src/_assets/scss/inc/infoblocks.scss
+++ b/src/_assets/scss/inc/infoblocks.scss
@@ -12,7 +12,7 @@
 .infoblock.is--warning {
 	--info-color: var(--swup-red);
 }
-.infoblock:before {
+.infoblock::before {
 	content: '';
 	display: block;
 	position: absolute;
@@ -20,14 +20,14 @@
 	left: 0;
 	border-left: 3px solid var(--info-color);
 }
-.infoblock:after {
+.infoblock::after {
 	content: '';
 	pointer-events: none;
 	position: absolute;
 	display: block;
 	inset: 0;
-	background: var(--info-color);
-	z-index: -1;
+	background-color: var(--info-color);
+	z-index: 0;
 	opacity: 0.2;
 	@at-root .dark & {
 		opacity: 0.3;


### PR DESCRIPTION
Fixes the background color of info blocks being invisible due to a negative z-index.

**Current**

![image](https://github.com/swup/docs/assets/869813/dd32826f-b6ec-4486-9612-06188cdb0a10)

**Fixed**

![image](https://github.com/swup/docs/assets/869813/bfc578fb-ebc2-4fe6-a397-620bd64d6a71)
**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
