### PR TITLE
Replace `--soure` with `--site` in pagefind script

### DIFF
--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -85,7 +85,7 @@ module.exports = function (eleventyConfig) {
 
 	// Run PageFind after every regeneration
 	eleventyConfig.on('eleventy.after', () => {
-		execSync(`npx pagefind --source _site`, {
+		execSync(`npx pagefind --site _site`, {
 			encoding: 'utf-8'
 		});
 	});


### PR DESCRIPTION
**Description**

Pagefind deprecated `--source` in favor of the new `--site` option in `v1.0`. Use that.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
