### PR TITLE
Improve compatibility with Safari 13

### DIFF
--- a/src/_assets/scss/inc/intro.scss
+++ b/src/_assets/scss/inc/intro.scss
@@ -66,7 +66,7 @@
 	display: block;
 	margin-inline: auto;
 	width: 100%;
-	aspect-ratio: 16 / 6.9;
+	@include mixins.aspectRatio(16, 6.9);
 	position: relative;
 	@at-root .dark & {
 		filter: drop-shadow(4px 4px 1px rgba(0 0 0 / 0.4));

--- a/src/_assets/scss/inc/intro.scss
+++ b/src/_assets/scss/inc/intro.scss
@@ -4,6 +4,7 @@
 	align-items: center;
 	justify-content: center;
 	text-align: center;
+	min-height: 100vh;
 	min-height: 100svh;
 
 	@at-root .light & {
@@ -44,6 +45,7 @@
 	padding-inline: var(--size-fluid-3);
 	position: relative;
 	// transform: translateY(-5%);
+	min-height: 100vh;
 	min-height: 100svh;
 }
 

--- a/src/_assets/scss/inc/mixins.scss
+++ b/src/_assets/scss/inc/mixins.scss
@@ -24,3 +24,12 @@
 		@content;
 	}
 }
+
+@mixin aspectRatio($width, $height) {
+	width: 100%;
+	padding-bottom: calc(100% / (#{$width} / #{$height}));
+	@supports (aspect-ratio: 1 / 1) {
+		padding-bottom: 0;
+		aspect-ratio: #{$width} / #{$height};
+	}
+}

--- a/src/_assets/scss/inc/nav.scss
+++ b/src/_assets/scss/inc/nav.scss
@@ -1,4 +1,5 @@
 .nav--desktop {
+	height: calc(100vh - var(--header-height));
 	height: calc(100svh - var(--header-height));
 	position: sticky;
 	top: var(--header-height);

--- a/src/_assets/scss/inc/page.scss
+++ b/src/_assets/scss/inc/page.scss
@@ -81,7 +81,7 @@
 	.video-embed,
 	.embed-responsive {
 		width: 100%;
-		aspect-ratio: 16 / 9;
+		@include mixins.aspectRatio(16, 9);
 
 		iframe {
 			width: 100%;

--- a/src/_assets/scss/inc/page.scss
+++ b/src/_assets/scss/inc/page.scss
@@ -80,10 +80,14 @@
 
 	.video-embed,
 	.embed-responsive {
+		position: relative;
 		width: 100%;
 		@include mixins.aspectRatio(16, 9);
 
 		iframe {
+			position: absolute;
+			top: 0;
+			left: 0;
 			width: 100%;
 			height: 100%;
 			margin: 0;

--- a/src/_assets/scss/inc/toc.scss
+++ b/src/_assets/scss/inc/toc.scss
@@ -2,6 +2,7 @@
 * TOC
 */
 .toc {
+	height: calc(100vh - var(--header-height));
 	height: calc(100svh - var(--header-height));
 	position: sticky;
 	top: var(--header-height);

--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -14,8 +14,18 @@
       document.documentElement.classList.remove('light', 'dark');
       document.documentElement.classList.add(getColorSchemePreference());
     }
-    colorSchemeMediaQuery.addEventListener('change', setColorThemeClass);
     setColorThemeClass();
+
+    try {
+      colorSchemeMediaQuery.addEventListener('change', setColorThemeClass);
+    } catch (e1) {
+      try {
+        // Safari < 14 fallback
+        colorSchemeMediaQuery.addListener(setColorThemeClass);
+      } catch (e2) {
+        console.error(e2);
+      }
+    }
   </script>
 
   <meta charset="UTF-8">


### PR DESCRIPTION
**Description**

- With the docs styling updates, we've introduced some newer properties like `100svh` and `aspect-ratio`
- When investigating [this bug on Safari 13](https://github.com/swup/swup/issues/822), I've noticed these aren't supported on older browsers
- This PR adds fallbacks for those new properties
- Also adds fallback for the media query event listener to enable dark mode on Safari 13

**Before**

<img width="1077" alt="Screenshot 2023-11-15 at 20 11 43" src="https://github.com/swup/docs/assets/22225348/60fe0bf2-c3b5-4310-b61d-8ab16391c82a">

  
**After**

<img width="1073" alt="Screenshot 2023-11-15 at 20 12 39" src="https://github.com/swup/docs/assets/22225348/b552fec4-b002-44ba-965e-2ef8d670857f">

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
