### PR TITLE
Add docs about animation methods and native mode

### DIFF
--- a/src/docs/announcements/swup-4.md
+++ b/src/docs/announcements/swup-4.md
@@ -25,6 +25,7 @@ Make your site feel like a snappy single-page app — without any of the complex
 ## What’s new in this release
 
 - [Official Astro integration](#astro-integration)
+- [Native View Transition support](#view-transitions)
 - [Built-in scroll support](#scroll-support)
 - [Local animation scope](#local-animation-scope)
 - [Hook system for easier customization](#hook-system)
@@ -52,6 +53,39 @@ for performance and accessibility out-of-the-box. Astro's bundling and module lo
 not hurting performance by only loading swup once the page has finished rendering.
 
 ## Features
+
+### Native View Transition support {#view-transitions}
+
+The new [View Transitions](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
+browser API provides a native and performant mechanism for managing the visual transition of
+elements from one state to another. This is great for page transition animations.
+
+Use swup's new `native` option to start definining your page transitions as native View Transitions.
+In addition, swup still supports CSS animations and JS animations. Learn more about
+[supported animation methods](/getting-started/animations/).
+
+```js
+const swup = new Swup({ native: true });
+```
+
+```css
+html.is-changing .transition-fade {
+  view-transition-name: main;
+}
+
+::view-transition-old(main) {
+  animation: fade 0.5s ease-in-out both;
+}
+
+::view-transition-new(main) {
+  animation: fade 0.5s ease-in-out both reverse;
+}
+
+@keyframes fade {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+```
 
 ### Built-in scroll support {#scroll-support}
 

--- a/src/docs/getting-started/animations.md
+++ b/src/docs/getting-started/animations.md
@@ -73,6 +73,8 @@ If you need to choose between different animations based on the URL, or if you h
 complex requirements, you can look into the official [JS Plugin](/plugins/js-plugin/).
 
 ```js
+import gsap from 'gsap';
+
 swup.hooks.replace('animation:out:await', async () => {
   await gsap.to('.transition-fade', { opacity: 0, duration: 0.25 });
 });

--- a/src/docs/getting-started/animations.md
+++ b/src/docs/getting-started/animations.md
@@ -1,0 +1,142 @@
+---
+layout: default
+title: Defining Animations
+eleventyNavigation:
+  key: Animations
+  parent: Getting Started
+  order: 4
+description: How to define page animations
+permalink: /getting-started/animations/
+---
+
+# Defining Animations
+
+Swup can be used with a variety of animation methods. It supports **CSS animations**, custom
+**JS animations**, as well as **native animations** using the View Transitions API.
+
+All code examples below assume the page markup from our [example setup](/getting-started/example/).
+
+```html
+<main id="swup" class="transition-fade">
+  <h1>Welcome</h1>
+  <p>Lorem ipsum dolor sit amet.</p>
+</main>
+```
+
+## CSS animations
+
+Swup's default mode is built around CSS animations. It will wait for any
+[transitions](https://developer.mozilla.org/en-US/docs/Web/CSS/transition) and
+[animations](https://developer.mozilla.org/en-US/docs/Web/CSS/animation) to finish before replacing
+page content. To identify animations to wait for, swup will look for a special type of class added
+to content containers: `transition-[name]`, where `name` is an arbitrary name you can assign
+to allow styling different types of animations. This [animation selector](/options/#animation-selector)
+can be freely configured.
+
+Your page transition animations are defined on the special transition class:
+
+```css
+html.is-changing .transition-fade {
+  transition: opacity 0.25s;
+  opacity: 1;
+}
+
+html.is-animating .transition-fade {
+  opacity: 0;
+}
+```
+
+### Animation classes {#classes}
+
+Swup applies classes to the `html` element to control the page transition process:
+
+<div class="events-table" data-table-with-anchor-links>
+
+| Class name            | Description                                                                                                                                                                                                                       |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `is-changing`         | Added before starting the animation. Removed after the whole animation process. Used for showing the loading state.                                                                                                               |
+| `is-animating`        | Added before starting the animation. Removed after the content is replaced. Used for defining styles of unloaded pages.                                                                                                           |
+| `is-leaving`          | Added before starting the animation. Removed right before the content is replaced. Used to identify the **leave** phase of the animation. Combine with `is-animating` to create differing **leave** and **enter** animations.     |
+| `is-rendering`        | Added right before the content is replaced. Removed after the whole animation process. Used to identify the **enter** phase of the animation. Combine with `is-animating` to create differing **leave** and **enter** animations. |
+| `to-[animation-name]` | Added for links with a `[data-swup-animation="{{animation-name}}"]` attribute to change the animation for a specific visit.                                                                                                       |
+
+</div>
+
+You can configure swup to [add animation classes to the containers](/options/#animation-scope)
+instead of the html element.
+
+## JS animations
+
+If you'd rather manage your animations in JS using your favorite animation library, you can use
+the appropriate hooks to await your custom animations instead. This is enough for most scenarios.
+If you need to choose between different animations based on the URL, or if you have other, more
+complex requirements, you can look into the official [JS Plugin](/plugins/js-plugin/).
+
+```js
+swup.hooks.replace('animation:out:await', async () => {
+  await gsap.to('.transition-fade', { opacity: 0, duration: 0.25 });
+});
+
+swup.hooks.replace('animation:in:await', async () => {
+  await gsap.fromTo('.transition-fade', { opacity: 0 }, { opacity: 1, duration: 0.25 });
+});
+```
+
+## Native animations
+
+The browser's built-in [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
+provides a native mechanism for managing transitions from one state to another. This is great for
+page transition animations as it allows better performance than CSS or JS animations on their own.
+
+To enable native animations, set the `native` option:
+
+```js
+const swup = new Swup({ native: true });
+```
+
+Define the view transitions in CSS, e.g. a simple crossfade:
+
+```css
+html.is-changing .transition-fade {
+  view-transition-name: main;
+}
+
+::view-transition-old(main) {
+  animation: fade 0.5s ease-in-out both;
+}
+
+::view-transition-new(main) {
+  animation: fade 0.5s ease-in-out both reverse;
+}
+
+@keyframes fade {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+```
+
+The above example will only animate in [browsers with support](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API#browser_compatibility)
+for the View Transitions API. All other browsers will update the page without animation. If you
+require a fallback animation, you can make use of the `swup-native` class added when native mode is
+enabled and supported. By checking for its absence, you can target unsupported browsers:
+
+```css
+html.is-changing:not(.swup-native) .transition-fade {
+  transition: 0.25s opacity;
+  opacity: 1;
+}
+
+html.is-animating:not(.swup-native) .transition-fade {
+  opacity: 0;
+}
+```
+
+## Usage without animations
+
+Swup works perfectly fine if none of your elements is animated. You might see a console warning
+"no CSS animation duration defined", which is safe to ignore. If it bothers you, set the
+animation selector to false:
+
+```js
+const swup = new Swup({ animationSelector: false });
+```

--- a/src/docs/getting-started/animations.md
+++ b/src/docs/getting-started/animations.md
@@ -11,8 +11,8 @@ permalink: /getting-started/animations/
 
 # Defining Animations
 
-Swup can be used with a variety of animation methods. It supports **CSS animations**, custom
-**JS animations**, as well as **native animations** using the View Transitions API.
+Swup can be used with a variety of animation methods. It supports **CSS animations**, custom
+**JS animations**, as well as **native animations** using the View Transitions API.
 
 All code examples below assume the page markup from our [example setup](/getting-started/example/).
 
@@ -46,9 +46,7 @@ html.is-animating .transition-fade {
 }
 ```
 
-### Animation classes {#classes}
-
-Swup applies classes to the `html` element to control the page transition process:
+Swup applies the following classes to the `html` element to control the page transition process:
 
 <div class="events-table" data-table-with-anchor-links>
 
@@ -133,7 +131,7 @@ html.is-animating:not(.swup-native) .transition-fade {
 }
 ```
 
-## Usage without animations
+## No animations
 
 Swup works perfectly fine if none of your elements is animated. You might see a console warning
 "no CSS animation duration defined", which is safe to ignore. If it bothers you, set the

--- a/src/docs/getting-started/demos.md
+++ b/src/docs/getting-started/demos.md
@@ -4,7 +4,7 @@ title: Demos
 eleventyNavigation:
   key: Demos
   parent: Getting Started
-  order: 4
+  order: 5
 description: Demonstrations
 permalink: /getting-started/demos/
 ---

--- a/src/docs/getting-started/example.md
+++ b/src/docs/getting-started/example.md
@@ -51,7 +51,7 @@ html.is-animating .transition-fade {
 ```
 
 For this example, we're using CSS to animate our page transition. Swup also supports JS animations
-and native View Transitions. [Learn more about defining animations](/getting-started/animations/).
+and native View Transitions. Learn more about [defining animations](/getting-started/animations/).
 
 ## 3. Initialize swup
 

--- a/src/docs/getting-started/example.md
+++ b/src/docs/getting-started/example.md
@@ -50,6 +50,9 @@ html.is-animating .transition-fade {
 }
 ```
 
+For this example, we're using CSS to animate our page transition. Swup also supports JS animations
+and native View Transitions. [Learn more about defining animations](/getting-started/animations/).
+
 ## 3. Initialize swup
 
 Finally, we'll load and initialize swup. And we're good to go!

--- a/src/docs/getting-started/example.md
+++ b/src/docs/getting-started/example.md
@@ -31,8 +31,7 @@ want to wait for this element to finish animating whenever a new page is loaded.
 </main>
 ```
 
-> **Note** These are just the defaults. Both the container selector and the animation selector are
-adjustable in the [options](/options/).
+> **Note** The container selector and animation selector are defaults and can be adjusted in the [options](/options/).
 
 ## 2. Animation styles
 

--- a/src/docs/getting-started/getting-started.md
+++ b/src/docs/getting-started/getting-started.md
@@ -38,7 +38,7 @@ Make your site feel like a snappy single-page app — without any of the complex
   <li class="feature">
     <span class="feature_icon">✨</span>
     <span class="feature_text">
-      Auto-detects <a href="/getting-started/how-it-works/#timing">CSS transitions</a> & animations for perfect timing
+      Auto-detects <a href="/getting-started/how-it-works/#timing">animations</a> for perfect timing
     </span>
   </li>
 

--- a/src/docs/getting-started/how-it-works.md
+++ b/src/docs/getting-started/how-it-works.md
@@ -25,40 +25,9 @@ menus.
 
 ## Automatic animation timing {#timing}
 
-Swup is built around CSS animations. It will wait for any
-[transitions](https://developer.mozilla.org/en-US/docs/Web/CSS/transition) and
-[animations](https://developer.mozilla.org/en-US/docs/Web/CSS/animation) to finish before replacing
-page content. To identify animations to wait for, swup will look for a special type of class added
-to content containers: `transition-[name]`, where `name` is an arbitrary name you can assign
-to allow styling different types of animations. This [animation selector](/options/#animation-selector)
-can be freely configured.
-
-It is recommended to only add this class to a **single** element per page. All other elements
-can be animated independently to allow easier debugging of animations.
-
-### Animation classes {#classes}
-
-Swup applies classes to the `html` element to control the page transition process:
-
-<div class="events-table" data-table-with-anchor-links>
-
-| Class name            | Description                                                                                                                                                                                                                       |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `is-changing`         | Added before starting the animation. Removed after the whole animation process. Used for showing the loading state.                                                                                                               |
-| `is-animating`        | Added before starting the animation. Removed after the content is replaced. Used for defining styles of unloaded pages.                                                                                                           |
-| `is-leaving`          | Added before starting the animation. Removed right before the content is replaced. Used to identify the **leave** phase of the animation. Combine with `is-animating` to create differing **leave** and **enter** animations.     |
-| `is-rendering`        | Added right before the content is replaced. Removed after the whole animation process. Used to identify the **enter** phase of the animation. Combine with `is-animating` to create differing **leave** and **enter** animations. |
-| `to-[animation-name]` | Added for links with a `[data-swup-animation="{{animation-name}}"]` attribute to change the animation for a specific visit.                                                                                                       |
-
-</div>
-
-You can configure swup to [add animation classes to the containers](/options/#animation-scope)
-instead of the html element.
-
-## Other animation methods
-
-Use the official [JS Plugin](/plugins/js-plugin/) to perform animations yourself in JS or with a
-popular animation library like GSAP.
+Swup is built around animations and will wait for CSS animations, JS animations, and native
+View Transitions before updating the page with the new content. See
+[Defining animations](/getting-started/animations/) for details and examples.
 
 ## Browser history {#history}
 

--- a/src/docs/options/options.md
+++ b/src/docs/options/options.md
@@ -159,7 +159,7 @@ other link and perform a regular navigation.
 
 Enable native animations using the [View Transitions](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
 API. This will toggle the class `swup-native` on the HTML element if View Transitions are supported
-by the user's browsers.
+by the user's browsers. Learn more about [native view transitions](/getting-started/animations/#native-animations).
 
 ## requestHeaders
 

--- a/src/docs/options/options.md
+++ b/src/docs/options/options.md
@@ -27,6 +27,7 @@ const swup = new Swup({
   ignoreVisit: (url, { el } = {}) => el?.closest('[data-no-swup]'),
   linkSelector: 'a[href]',
   linkToSelf: 'scroll',
+  native: false,
   plugins: [],
   resolveUrl: (url) => url,
   requestHeaders: {
@@ -153,6 +154,12 @@ other link and perform a regular navigation.
   linkToSelf: 'navigate'
 }
 ```
+
+## native
+
+Enable native animations using the [View Transitions](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
+API. This will toggle the class `swup-native` on the HTML element if View Transitions are supported
+by the user's browsers.
 
 ## requestHeaders
 


### PR DESCRIPTION
- Add documentation for `native` option
- Create page "Defining animations" that explains different animation methods
- Add examples for each: CSS + JS + Native + None
- Add View Transition Support to v4 releases notes: great place to advertise this
- Update wording to reflect that swup supports many animation methods
- Should only be merged once swup 4.5 is released
