### PR TITLE
Optimize display of linked images

### DIFF
--- a/src/_assets/scss/inc/page.scss
+++ b/src/_assets/scss/inc/page.scss
@@ -30,6 +30,11 @@
 		}
 	}
 
+	// Images wrapped in links: remove underline
+	a:has(img:only-child) {
+		background-image: none;
+	}
+
 	> * + * {
 		margin-block: 1em 0;
 	}


### PR DESCRIPTION
- Improve styling of shields/badges
- Currently, all links have a visual underline meant for text links
- This change removes the underline for all links that only contain images