### PR TITLE
Add support for official GitHub warning markup

### DIFF
--- a/lib/eleventy-transforms.js
+++ b/lib/eleventy-transforms.js
@@ -80,26 +80,36 @@ function prepareInfoBlocks(html, file) {
 	};
 
 	doc.querySelectorAll('.page_body blockquote').forEach((quote) => {
-		if (!quote.innerHTML.trim().startsWith('<p><strong>')) return;
-		const firstStrongElement = quote.querySelector('strong:first-child');
-		if (!firstStrongElement) return;
-		const label = firstStrongElement.textContent
-			?.replace(/[^a-z0-9\s]/gi, '')
-			.toLowerCase()
-			.trim();
-		const type = types[label];
-		if (!type) return;
+		const html = quote.innerHTML.trim();
+		let label = '';
 
-		firstStrongElement.textContent = toTitleCase(label);
+		if (html.startsWith('<p>[!')) {
+			const paragraphEl = quote.querySelector('p:first-child');
+			paragraphEl.innerHTML = paragraphEl.innerHTML.replace(/^\s*(\[!)(\w+)(\])\s*(<br\s*\/?>)?/g, '<strong>$2</strong>');
+		}
+
+		const labelEl = quote.querySelector('p:first-child strong:first-child');
+		if (!labelEl) return;
+		label = labelEl?.textContent ?? '';
+		labelEl.remove();
+
+		label = label.replace(/[^a-z0-9\s]/gi, '').toLowerCase().trim();
+		const type = types[label];
+
+		console.log({ label, type });
+		if (!type) return;
 
 		const icon = doc.createElement('span');
 		icon.classList.add('infoblock_icon');
 		icon.innerHTML = feather.icons[type.icon].toSvg();
 
+		const strong = doc.createElement('strong');
+		strong.textContent = toTitleCase(label);
+
 		const header = doc.createElement('h6');
 		header.classList.add('infoblock_header');
 		header.append(icon);
-		header.append(firstStrongElement);
+		header.append(strong);
 
 		const aside = doc.createElement('aside');
 		aside.classList.add('infoblock', `is--${label}`);

--- a/lib/eleventy-transforms.js
+++ b/lib/eleventy-transforms.js
@@ -90,7 +90,7 @@ function prepareInfoBlocks(html, file) {
 		const type = types[label];
 		if (!type) return;
 
-		firstStrongElement.textContent = toTitleCase(`${label}:`);
+		firstStrongElement.textContent = toTitleCase(label);
 
 		const icon = doc.createElement('span');
 		icon.classList.add('infoblock_icon');

--- a/lib/eleventy-transforms.js
+++ b/lib/eleventy-transforms.js
@@ -59,14 +59,23 @@ function prepareInfoBlocks(html, file) {
 	const doc = dom.window.document;
 
 	const types = {
-		warning: {
-			icon: 'alert-triangle'
+		info: {
+			icon: 'info'
 		},
 		note: {
 			icon: 'info'
 		},
-		info: {
-			icon: 'info'
+		tip: {
+			icon: 'zap'
+		},
+		important: {
+			icon: 'alert-circle'
+		},
+		warning: {
+			icon: 'alert-triangle'
+		},
+		caution: {
+			icon: 'alert-octagon'
 		}
 	};
 

--- a/src/_assets/scss/inc/infoblocks.scss
+++ b/src/_assets/scss/inc/infoblocks.scss
@@ -9,7 +9,8 @@
 	}
 	border-radius: var(--radius-1);
 }
-.infoblock.is--warning {
+.infoblock.is--warning,
+.infoblock.is--caution {
 	--info-color: var(--swup-red);
 }
 .infoblock::before {


### PR DESCRIPTION
**Description**

- Support [GitHub's official markdown warning format](https://github.com/orgs/community/discussions/16925)
- Ensure identical rendering in readmes vs. the official docs
- The old format is actually no longer supported, but I thought no harm in leaving it in
- We only have green and red, so I made warning and caution red, everything else green
- There's no lightbulb icon in feather, but the zap icon felt close enough conceptionally

**New format (now supported)**

```md
> [!NOTE]  
> Highlights information that users should take into account, even when skimming.

> [!TIP]
> Optional information to help a user be more successful.

> [!IMPORTANT]  
> Crucial information necessary for users to succeed.

> [!WARNING]  
> Critical content demanding immediate user attention due to potential risks.

> [!CAUTION]
> Negative potential consequences of an action.
```

**Old format (still supported)**

```md
> **Note**
> This is a note

> **Warning**
> This is a warning
```

**Screenshot**

<img width="1405" alt="Screenshot 2024-04-12 at 18 09 27" src="https://github.com/swup/docs/assets/22225348/0baf5a69-2a17-4d33-afd8-e0120311ad02">

**Checks**

- [ ] The PR is submitted to the `master` branch
- [ ] The code was linted before pushing (`npm run lint`)
- [ ] All tests are passing (`npm run test`)
- [ ] New or updated tests are included
- [ ] The documentation was updated as required

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
