### PR TITLE
Split plugins and integrations in menu

### DIFF
--- a/src/docs/integrations/alpine.md
+++ b/src/docs/integrations/alpine.md
@@ -1,37 +1,15 @@
 ---
 layout: default
-title: Integrations
+title: Integrating Alpine.js
 eleventyNavigation:
-  key: Integrations
-  parent: Other
-  order: 1
-description: Integrating swup with other tools
-permalink: /other/integrations/
+  key: Alpine.js
+  parent: Integrations
+  order: 2
+description: How to integrate Alpine and swup
+permalink: /integrations/alpine/
 ---
 
-# Integrations
-
-This is a collection of solutions for integrating swup with other popular tools.
-
-## Astro
-
-Astro and swup are a great fit. Where Astro manages the rendering of your site, swup takes over
-and adds smooth page transitions, smart preloading and caching on the client side.
-
-Check out the [official Astro integration for swup](https://github.com/swup/astro)
-for getting started quickly.
-
-```js
-// astro.config.mjs
-import { defineConfig } from 'astro/config';
-import swup from '@swup/astro';
-
-export default defineConfig({
-  integrations: [swup()]
-});
-```
-
-## Alpine.js
+# Integrating Alpine.js
 
 Swup works well with [Alpine.js](https://alpinejs.dev/) for managing component
 state and automating page lifecycles. Just initialize both libraries and enjoy
@@ -53,7 +31,7 @@ Alpine.start();
 </div>
 ```
 
-### Handling swup hooks
+## Handling swup hooks
 
 To register handlers for swup's hooks inside your Alpine components, you need to
 prepend `swup` to all hook names. You can access swup's visit object using the

--- a/src/docs/integrations/astro.md
+++ b/src/docs/integrations/astro.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: Astro Integration
+eleventyNavigation:
+  key: Astro
+  parent: Integrations
+  order: 1
+description: Official Astro integration
+permalink: /integrations/astro/
+---
+
+# Astro Integration
+
+Astro and swup are a great fit. Where Astro manages the rendering of your site, swup takes over
+and adds smooth page transitions, smart preloading and caching on the client side.
+
+Check out the [official Astro integration for swup](https://github.com/swup/astro)
+for getting started quickly.
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import swup from '@swup/astro';
+
+export default defineConfig({
+  integrations: [swup()]
+});
+```

--- a/src/docs/integrations/integrations.md
+++ b/src/docs/integrations/integrations.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Integrations
+eleventyNavigation:
+  key: Integrations
+  order: 5
+  url: /plugins/#official-integrations
+description: List of available official integrations
+permalink: false
+---

--- a/src/docs/plugins/ga-plugin.md
+++ b/src/docs/plugins/ga-plugin.md
@@ -3,8 +3,8 @@ layout: default
 title: GA Plugin
 eleventyNavigation:
   key: GA Plugin
-  parent: Plugins
-  order: 8
+  parent: Integrations
+  order: 3
 description: A swup plugin for integrating Google Analytics
 permalink: /plugins/ga-plugin/
 repo_link: https://github.com/swup/ga-plugin

--- a/src/docs/plugins/gia-plugin.md
+++ b/src/docs/plugins/gia-plugin.md
@@ -3,8 +3,8 @@ layout: default
 title: Gia Plugin
 eleventyNavigation:
   key: Gia Plugin
-  parent: Plugins
-  order: 9
+  parent: Integrations
+  order: 4
 description: A swup plugin for integrating Gia frontend components
 permalink: /plugins/gia-plugin/
 repo_link: https://github.com/swup/gia-plugin

--- a/src/docs/plugins/gtm-plugin.md
+++ b/src/docs/plugins/gtm-plugin.md
@@ -3,8 +3,8 @@ layout: default
 title: GTM Plugin
 eleventyNavigation:
   key: GTM Plugin
-  parent: Plugins
-  order: 10
+  parent: Integrations
+  order: 5
 description: Plugin to trigger GTM page view events
 permalink: /plugins/gtm-plugin/
 repo_link: https://github.com/swup/gtm-plugin

--- a/src/docs/plugins/livewire-plugin.md
+++ b/src/docs/plugins/livewire-plugin.md
@@ -3,8 +3,8 @@ layout: default
 title: Livewire Plugin
 eleventyNavigation:
   key: Livewire Plugin
-  parent: Plugins
-  order: 13
+  parent: Integrations
+  order: 6
 description: A swup plugin for integrating Laravel Livewire
 permalink: /plugins/livewire-plugin/
 repo_link: https://github.com/swup/livewire-plugin

--- a/src/docs/plugins/matomo-plugin.md
+++ b/src/docs/plugins/matomo-plugin.md
@@ -3,8 +3,8 @@ layout: default
 title: Matomo Plugin
 eleventyNavigation:
   key: Matomo Plugin
-  parent: Plugins
-  order: 14
+  parent: Integrations
+  order: 7
 description: A swup plugin for integrating Matomo analytics
 permalink: /plugins/matomo-plugin/
 repo_link: https://github.com/swup/matomo-plugin

--- a/src/docs/plugins/plugins.md
+++ b/src/docs/plugins/plugins.md
@@ -16,7 +16,7 @@ See below for details on [installing and enabling plugins](#installing-plugins).
 
 ## Official plugins
 
-These are plugins developed and maintained by the swup core team.
+Plugins extending swup's functionality, developed and maintained by the core team.
 
 |                        Plugin                         |                    Features                    |
 | ----------------------------------------------------- | ---------------------------------------------- |
@@ -36,10 +36,11 @@ These are plugins developed and maintained by the swup core team.
 
 ## Official integrations
 
-These are plugins connecting swup with other frameworks or services.
+Plugins or libraries connecting swup with other frameworks or services.
 
 |                   Plugin                    |     Integrates with     |
 | ------------------------------------------- | ----------------------- |
+| [Astro Integration](/integrations/astro)    | Astro.js                |
 | [GA Plugin](/plugins/ga-plugin)             | Google Analytics        |
 | [Gia Plugin](/plugins/gia-plugin)           | Gia frontend components |
 | [GTM Plugin](/plugins/gtm-plugin)           | Google Tag Manager      |

--- a/src/docs/themes/themes.md
+++ b/src/docs/themes/themes.md
@@ -3,7 +3,7 @@ layout: default
 title: Themes
 eleventyNavigation:
   key: Themes
-  order: 5
+  order: 6
 description: List of official themes
 permalink: /themes/
 ---

--- a/src/docs/third-party-plugins/third-party-plugins.md
+++ b/src/docs/third-party-plugins/third-party-plugins.md
@@ -3,8 +3,8 @@ layout: default
 title: Third-Party Plugins
 eleventyNavigation:
   key: Third-Party Plugins
-  order: 6
-description: List of external plugins done by awesome people around the web
+  order: 7
+description: List of external plugins created by awesome people around the web
 permalink: /third-party-plugins/
 ---
 


### PR DESCRIPTION
**Description**

- Separate plugins (extending functionality) and integrations (connecting with other libraries)
- Add separate Astro + Alpine pages
- Make the plugin list look less scary

**Screenshot**

<img width="1592" alt="Screenshot 2024-07-23 at 23 31 12" src="https://github.com/user-attachments/assets/0987f5bc-576b-4fdc-a3a8-1f90dd75bb70">

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [x] The documentation was updated as required