### PR TITLE
Add documentation for `visit.meta` object

### DIFF
--- a/src/docs/api/methods.md
+++ b/src/docs/api/methods.md
@@ -49,6 +49,13 @@ Disable the cache for this request:
 swup.navigate(url, { cache: { read: false, write: true } });
 ```
 
+Send along [custom metadata](/visit/#pass-along-custom-metadata) available in all hooks:
+
+```javascript
+swup.navigate(url, { meta: { lorem: 'ipsum' } })
+```
+
+
 ## destroy
 
 Disables swup.

--- a/src/docs/lifecycle/visit.md
+++ b/src/docs/lifecycle/visit.md
@@ -67,7 +67,8 @@ This is an example visit object for a navigation from `/home` to `/about#anchor`
   scroll: {
     reset: true,
     target: '#anchor'
-  }
+  },
+  meta: {}
 }
 ```
 
@@ -185,4 +186,25 @@ swup.hooks.on('content:replace', (visit) => {
   const lang = visit.to.document?.documentElement.getAttribute('lang');
   if (lang) document.documentElement.setAttribute('lang', lang);
 });
+```
+
+### Pass along custom metadata
+
+Each visit has an empty `meta` object you can use to store arbitrary data with that visit. The data
+will now be available in every hook handler along the way.
+
+```javascript
+swup.hooks.on('visit:start', (visit) => {
+  visit.meta.lorem = 'ipsum';
+});
+
+swup.hooks.on('page:view', (visit) => {
+  console.log(visit.meta.lorem); // 'ipsum'
+});
+```
+
+When initiating a visit from the navigation API, you can pass in a custom metadata object as well:
+
+```javascript
+swup.navigate(url, { meta: { lorem: 'ipsum' } })
 ```


### PR DESCRIPTION
**Description**

Document new `visit.meta` object for passing along custom data:

```js
swup.hooks.on('visit:start', (visit) => {
  visit.meta.lorem = 'ipsum';
});

swup.hooks.on('page:view', (visit) => {
  console.log(visit.meta.lorem); // 'ipsum'
});
```

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [x] The documentation was updated as required