### PR TITLE
Fix search bar opening issue when shortcut key is pressed

### DIFF
--- a/src/_assets/components/alpine/Search/Search.js
+++ b/src/_assets/components/alpine/Search/Search.js
@@ -3,8 +3,8 @@ export default () => {
 		isOpen: false,
 		metaKey: navigator.platform.indexOf('Mac') === 0 ? '⌘' : 'Ctrl+',
 		onKeyDown(e) {
-			if (e.key === '/') return this.open();
-			if (e.key === 'k' && (e.ctrlKey || e.metaKey)) {
+			if (e.key === '/' || (e.key === 'k' && (e.ctrlKey || e.metaKey))) {
+				e.preventDefault();
 				this.open();
 			}
 		},


### PR DESCRIPTION
<!--
Thanks for creating this pull request!

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple PRs instead of opening a huge one.
-->

**Description**

Fixed an issue where using shortcut keys on the website would open both the search bar on the site and the browser's search.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [ x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [x] The documentation was updated as required

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
