### PR TITLE
Prepare for renaming the default branch from `master` to `main`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GH pages
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   repository_dispatch:
     types: [ "redeploy_docs" ]
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main", "next"]
   pull_request:
-    branches: ["main", "next"]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-    branches: ["master", "next"]
+    branches: ["main", "next"]
   pull_request:
-    branches: ["master", "next"]
+    branches: ["main", "next"]
   workflow_dispatch:
 
 jobs:

--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -207,6 +207,7 @@ async function loadGitHubRepoFile(repoLink, filePath, type = 'text') {
 	repoLink = repoLink.replace(/\/$/, '');
 
 	const defaultBranch = await getDefaultBranch(repoLink);
+	console.log({ repoLink, defaultBranch });
 
 	const rawBase = repoLink.replace('//github.com', '//raw.githubusercontent.com');
 	const repoURL = `${rawBase}/${defaultBranch}/${filePath}`;

--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -16,6 +16,7 @@ const {
 	prepareInfoBlocks,
 	prepareVideos
 } = require('./lib/eleventy-transforms');
+const { getDefaultBranch } = require('./lib/helpers');
 
 const customMarkdownIt = markdownIt({
 	html: true,
@@ -202,8 +203,13 @@ async function maybeLoadPackageInfo(ctx) {
  * @param {string} type
  */
 async function loadGitHubRepoFile(repoLink, filePath, type = 'text') {
-	const repoBase = repoLink.replace('github.com', 'raw.githubusercontent.com');
-	const repoURL = `${repoBase}/master/${filePath}`;
+	/** Remove the trailing slash */
+	repoLink = repoLink.replace(/\/$/, '');
+
+	const defaultBranch = await getDefaultBranch(repoLink);
+
+	const rawBase = repoLink.replace('//github.com', '//raw.githubusercontent.com');
+	const repoURL = `${rawBase}/${defaultBranch}/${filePath}`;
 
 	try {
 		return await EleventyFetch(repoURL, { duration: '60s', type });

--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -211,7 +211,7 @@ async function loadGitHubRepoFile(repoLink, filePath, type = 'text') {
 		try {
 			return await EleventyFetch(repoURL.toLowerCase(), { duration: '60s', type });
 		} catch (error) {
-			console.error(`Erro loading ${filePath} from ${repoURL}: ${error.message}`);
+			console.error(`Error loading ${filePath} from ${repoURL}: ${error.message}`);
 			return null;
 		}
 	}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,71 @@
+// @ts-check
+
+const { execSync } = require('child_process');
+const { mkdtempSync, rmSync } = require('fs');
+const { tmpdir } = require('os');
+const { join } = require('path');
+
+/**
+ * Log and exit
+ */
+function dd(...args) {
+	console.log(...args);
+	process.exit();
+}
+
+/**
+ * A cache for default branches
+ * @type {Map<string, string>}
+ */
+const defaultBranches = new Map();
+
+/**
+ * Detect the default branch of a GitHub repo by cloning it
+ *
+ * @param {string} repoURL - HTTPS clone URL of the repo (e.g. https://github.com/user/repo.git)
+ * @return {Promise<string>} - Default branch name
+ */
+function getDefaultBranch(repoURL) {
+	repoURL = repoURL.replace(/\/$/, '') + '.git';
+
+	return new Promise((resolve) => {
+		const cached = defaultBranches.get(repoURL);
+		if (!!cached) {
+			resolve(cached);
+			return;
+		}
+
+		const tmpDir = mkdtempSync(join(tmpdir(), 'repo-'));
+
+		try {
+			// Bare, shallow clone for speed
+			execSync(`git clone --bare --depth=1 ${repoURL} .`, {
+				cwd: tmpDir,
+				stdio: 'ignore'
+			});
+
+			const output = execSync(`git remote show origin`, {
+				cwd: tmpDir
+			}).toString();
+
+			const match = output.match(/HEAD branch: (.+)/);
+			if (match) {
+				defaultBranches.set(repoURL, match[1].trim());
+				resolve(match[1].trim());
+				return;
+			}
+		} catch (error) {
+			console.error(`Error detecting default branch for ${repoURL}: ${error.message}`);
+		} finally {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+		defaultBranches.set(repoURL, 'master');
+		resolve('master');
+	});
+}
+
+
+module.exports = {
+	dd,
+	getDefaultBranch,
+};

--- a/src/_includes/page.njk
+++ b/src/_includes/page.njk
@@ -21,9 +21,9 @@
       <p>
         {% feather "edit" %}
         {% if repo_link %}
-          <a href="{{ repo_link }}/blob/master/README.md" target="_blank">Suggest changes to this page</a>
+          <a href="{{ repo_link }}/blob/main/README.md" target="_blank">Suggest changes to this page</a>
         {% else %}
-          <a href="https://github.com/swup/docs/blob/master/src{{ page.filePathStem }}.md" target="_blank">Suggest changes to this page</a>
+          <a href="https://github.com/swup/docs/blob/main/src{{ page.filePathStem }}.md" target="_blank">Suggest changes to this page</a>
         {% endif %}
       </p>
     </div>

--- a/src/docs/getting-started/getting-started.md
+++ b/src/docs/getting-started/getting-started.md
@@ -130,4 +130,4 @@ Become a sponsor on [Open Collective](https://opencollective.com/swup) or suppor
 
 ## License
 
-Swup is released under the [MIT license](https://github.com/swup/swup/blob/master/LICENSE).
+Swup is released under the [MIT license](https://github.com/swup/swup/blob/main/LICENSE).

--- a/src/docs/getting-started/showcase.md
+++ b/src/docs/getting-started/showcase.md
@@ -14,4 +14,4 @@ permalink: /getting-started/showcase/
 A small selection of sites using swup to enhance their navigation experience.
 
 Want to share a site you've built?
-[Submit it to the showcase](https://github.com/swup/docs/blob/master/src/showcase/README.md).
+[Submit it to the showcase](https://github.com/swup/docs/blob/main/src/showcase/README.md).

--- a/src/docs/other/changelog.md
+++ b/src/docs/other/changelog.md
@@ -5,6 +5,6 @@ eleventyNavigation:
   key: Changelog
   parent: Other
   order: 5
-  url: https://github.com/swup/swup/blob/master/CHANGELOG.md
+  url: https://github.com/swup/swup/blob/main/CHANGELOG.md
 permalink: false
 ---

--- a/src/docs/other/ci-cd.md
+++ b/src/docs/other/ci-cd.md
@@ -16,7 +16,7 @@ For this you can use [swup cli](/cli/), which now has a `validate` command with 
 
 Note that `validate` command runs test against a live site, while checking the pages in a headless browser.
 This means the site needs to be running on some domain, or can be temporarily started just for checks.
-You can use this docs site as an example, which is using a [CircleCI pipeline](https://github.com/swup/docs/blob/master/.circleci/config.yml) with [http-server package](https://github.com/swup/docs/blob/master/package.json#L20) to start a server and validate site on each PR.
+You can use this docs site as an example, which is using a [CircleCI pipeline](https://github.com/swup/docs/blob/main/.circleci/config.yml) with [http-server package](https://github.com/swup/docs/blob/main/package.json#L20) to start a server and validate site on each PR.
 
 Instead of using the [command line options](/cli/), you can also define the options in a `swup.config.js` file in the root of your project.
 This file needs to default export an object, similar to the one below.

--- a/src/showcase/README.md
+++ b/src/showcase/README.md
@@ -17,8 +17,8 @@ Adding your site to the Swup Showcase is straightforward.
     - This will copy the repository to your account, allowing you to make changes.
 
 2. **Prepare Your Showcase File**:
-    - Navigate to the [`showcase/`](https://github.com/swup/docs/tree/master/src/showcase) directory.
-    - Make a copy of the [`_showcase.md`](https://github.com/swup/docs/tree/master/src/showcase/_showcase.md) example file.
+    - Navigate to the [`showcase/`](https://github.com/swup/docs/tree/main/src/showcase) directory.
+    - Make a copy of the [`_showcase.md`](https://github.com/swup/docs/tree/main/src/showcase/_showcase.md) example file.
     - Rename your copy to something descriptive of your site (e.g., `your-site-name.md`).
     - Edit the file to include information about your website, following the template.
 


### PR DESCRIPTION
**Description**

Prepare for renaming the default branch from `master` to `main`

**Drive-By**

Automatically get the default branch of remote repos. This can also be used to detect the ones that are still at master when building the docs 🥸

![CleanShot 2025-08-05 at 10 00 45@2x](https://github.com/user-attachments/assets/d7eba235-bd16-4434-8375-feabc01dc2ef)

